### PR TITLE
feat: Auth API 구현, JWT/Security 기반 인증 인프라 구성 및 프로젝트 기본세팅 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,44 +1,81 @@
 # ========================================
 # getchu Environment Variables
 # ========================================
-# 사용 방법:
-# 1. cp .env.example .env
-# 2. .env 파일은 절대 Git에 커밋하지 않습니다.
+# 📌 사용 방법:
+# 1. cp .env.example .env        → .env 파일 생성
+# 2. .env 파일 열어서 값 채우기  → 아래 각 항목 설명 참고
+# 3. docker compose up --build   → 실행
+#
+# ⚠️  주의사항:
+# - .env 파일은 절대 Git에 커밋하지 않습니다
+# - 이 파일(.env.example)만 Git에 올립니다
 # ========================================
+
 
 # ========================================
 # Application Configuration
 # ========================================
+# 앱 외부 접근 포트 (브라우저에서 localhost:8080으로 접근)
 APP_EXTERNAL_PORT=8080
+
 
 # ========================================
 # Database Configuration
 # ========================================
-# Docker 실행 시 반드시 mysql:3306 사용 (localhost 아님 주의)
+# ⚠️  DB_URL 주의:
+# - Docker 실행 시 → mysql:3306    (컨테이너 내부 통신)
+# - IDE 직접 실행 시 → localhost:3307 (외부 포트로 접근)
+# - 현재 팀 룰: Docker로만 실행 → mysql:3306 고정
 DB_URL=jdbc:mysql://mysql:3306/getchu
+
+# DB 접속 계정 (MySQL root 계정 사용)
 DB_USERNAME=root
+
+# DB 비밀번호 (본인이 설정할 비밀번호 입력)
+# 예시: DB_PASSWORD=mypassword123
 DB_PASSWORD=root
 
-# MySQL 컨테이너 설정
+
+# ========================================
+# MySQL Container Configuration
+# ========================================
+# MySQL 컨테이너가 생성할 데이터베이스 이름 (변경 불필요)
 MYSQL_DATABASE=getchu
+
+# MySQL root 비밀번호 → 반드시 DB_PASSWORD와 동일한 값으로 설정
+# DB_PASSWORD=root 이면 MYSQL_ROOT_PASSWORD=root
 MYSQL_ROOT_PASSWORD=root
+
+# MySQL 외부 접근 포트 (IntelliJ Database 연결 시 3307로 접속)
 MYSQL_EXTERNAL_PORT=3307
+
 
 # ========================================
 # Redis Configuration
 # ========================================
-# Docker 실행 시 반드시 redis 사용 (localhost 아님 주의)
+# ⚠️  REDIS_HOST 주의:
+# - Docker 실행 시 → redis         (컨테이너 내부 통신)
+# - IDE 직접 실행 시 → localhost
+# - 현재 팀 룰: Docker로만 실행 → redis 고정
 REDIS_HOST=redis
+
+# Redis 포트 (변경 불필요)
 REDIS_PORT=6379
+
+# Redis 외부 접근 포트 (변경 불필요)
 REDIS_EXTERNAL_PORT=6379
+
 
 # ========================================
 # JWT Configuration
 # ========================================
-# 로컬 개발용 기본값 - 운영 배포 시 반드시 변경
+# JWT 서명 키 (32자 이상 랜덤 문자열 권장)
+# 예시: JWT_SECRET_KEY=getchu-my-secret-key-change-this-value
+# ⚠️  운영 배포 시 반드시 예측 불가능한 값으로 변경
 JWT_SECRET_KEY=local-dev-secret-key-please-change-in-production
 
-# Access Token 만료 시간 (밀리초)
-# 현재는 Refresh Token 미구현 상태이므로 임시로 24시간 설정
-# 추후 Refresh Token 도입 시 Access Token 만료시간 단축 예정
-JWT_ACCESS_EXPIRATION_TIME=86400000
+# Access Token 만료 시간 (밀리초) — 15분
+JWT_ACCESS_EXPIRATION_TIME=900000
+
+# Refresh Token 만료 시간 (밀리초) — 7일
+JWT_REFRESH_EXPIRATION_TIME=604800000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,15 @@ COPY gradle gradle
 COPY gradlew build.gradle settings.gradle ./
 
 # 2. 의존성 다운로드 (소스 코드 변경되어도 캐시됨)
-RUN gradle dependencies --no-daemon || return 0
+RUN gradle dependencies --no-daemon || true
 
 # 3. 전체 소스코드 복사 후 빌드
 COPY src src
 RUN gradle build -x test --no-daemon
 
 # 실행 단계
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre
+# JRE만 포함 → 실행 단계에서 컴파일러 불필요 → 이미지 크기 감소
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,12 @@ dependencies {
 
     // Security & JWT
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'       // 0.11.5 → 0.12.6 업그레이드
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'       // 0.11.5 → 0.12.6 업그레이드 보안이슈
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // env
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     // JPA & DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 services:
   redis:
-    image: redis:7-alpine
+    # Redis 7.x 유지 이유:
+    # Redis 8.0부터 라이선스가 BSD → RSALv2/SSPLv1로 변경됨
+    # SSPLv1은 상업적 서비스에서 소스코드 공개 의무가 생길 수 있어
+    # 실무에서도 7.x LTS를 표준으로 사용하는 추세
+    # 7.4 = 현재 7.x 최신 안정 버전
+    image: redis:7.4-alpine
     container_name: getchu-redis
     ports:
-      - "${REDIS_EXTERNAL_PORT:-6379}:6379"
+      - "${REDIS_EXTERNAL_PORT}:6379"
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
@@ -16,12 +21,12 @@ services:
       # 5번 연속 실패하면 컨테이너를 unhealthy 상태로 표시
 
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4 # 버전 업데이트 8.0 -> 8.4 / MySQL 8.0은 2026년 4월 EOL(지원 종료) 예정
     container_name: getchu-mysql
     ports:
-      - "${MYSQL_EXTERNAL_PORT:-3307}:3306"
+      - "${MYSQL_EXTERNAL_PORT}:3306"
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE:-getchu}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - mysql-data:/var/lib/mysql
@@ -38,16 +43,9 @@ services:
       dockerfile: Dockerfile
     container_name: getchu-app
     env_file:
-      - .env
+      - .env # .env 파일 전체를 컨테이너에 주입
     ports:
-      - "${APP_EXTERNAL_PORT:-8080}:8080"
-    environment:
-      DB_URL: ${DB_URL}
-      DB_USERNAME: ${DB_USERNAME}
-      DB_PASSWORD: ${DB_PASSWORD}
-      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
-      REDIS_HOST: ${REDIS_HOST:-redis}
-      REDIS_PORT: ${REDIS_PORT:-6379}
+      - "${APP_EXTERNAL_PORT}:8080"
     depends_on:
       mysql:
         condition: service_healthy

--- a/scripts/compose-up.sh
+++ b/scripts/compose-up.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# ================================================================
+# Day 17 - 풀스택 기동 스크립트
+#
+# 실행 순서:
+#   1) ./gradlew bootJar   — 실행 가능한 jar 빌드
+#   2) docker compose up -d --build  — 이미지 빌드 + 컨테이너 기동
+#
+# IntelliJ Run Configuration > Shell Script 에서 이 파일을 지정합니다.
+# Working directory 를 반드시 프로젝트 루트($ProjectFileDir$)로 설정해야
+# Gradle wrapper와 docker-compose.yml 경로가 올바르게 잡힙니다.
+# ================================================================
+set -e   # 중간 명령 실패 시 즉시 종료 (bootJar 실패 → compose up 건너뜀)
+
+echo "=== [1/2] Gradle bootJar 빌드 시작 ==="
+./gradlew bootJar
+
+echo "=== [2/2] Docker Compose 풀스택 기동 ==="
+docker compose up -d --build
+
+echo "=== 기동 완료 — 앱 로그 출력 시작 (중지: Ctrl+C) ==="
+docker compose logs -f app

--- a/src/main/java/com/clone/getchu/GetchuApplication.java
+++ b/src/main/java/com/clone/getchu/GetchuApplication.java
@@ -2,7 +2,9 @@ package com.clone.getchu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GetchuApplication {
 

--- a/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
@@ -7,10 +7,7 @@ import com.clone.getchu.domain.auth.dto.SignupRequest;
 import com.clone.getchu.domain.auth.dto.SignupResponse;
 import com.clone.getchu.domain.auth.service.AuthService;
 import com.clone.getchu.global.common.ApiResponse;
-import com.clone.getchu.global.exception.ErrorCode;
-import com.clone.getchu.global.exception.UnauthorizedException;
 import com.clone.getchu.global.security.CustomUserDetails;
-import com.clone.getchu.global.security.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,10 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final AuthService authService;
-    private final JwtProvider jwtProvider;
 
     /**
      * 회원가입
@@ -93,13 +87,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             HttpServletRequest request) {
-        // SecurityContext에 저장된 인증 정보를 통해 안전하게 memberId를 전달합니다.
-        // 클라이언트가 보낸 원본 토큰 문자열은 request에서 추출합니다.
-        String accessToken = jwtProvider.resolveToken(request);
-        if (accessToken == null) {
-            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
-        }
-        authService.logout(userDetails.getMemberId(), accessToken);
+        authService.logout(userDetails.getMemberId(), request);
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다.", null));
     }
 }

--- a/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
@@ -8,14 +8,17 @@ import com.clone.getchu.domain.auth.dto.SignupResponse;
 import com.clone.getchu.domain.auth.service.AuthService;
 import com.clone.getchu.global.common.ApiResponse;
 import com.clone.getchu.global.exception.ErrorCode;
-import com.clone.getchu.global.exception.InvalidRequestException;
+import com.clone.getchu.global.exception.UnauthorizedException;
+import com.clone.getchu.global.security.CustomUserDetails;
+import com.clone.getchu.global.security.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,14 +30,15 @@ public class AuthController {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final AuthService authService;
+    private final JwtProvider jwtProvider;
 
     /**
      * 회원가입
      * POST /auth/signup
-     *
+     * <p>
      * 성공: 201 Created + SignupResponse (id, email, nickname)
      * 실패: 409 DUPLICATE_EMAIL  (이메일 중복)
-     *       400 INVALID_REQUEST  (@Valid 검증 실패)
+     * 400 INVALID_REQUEST  (@Valid 검증 실패)
      */
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(
@@ -48,10 +52,10 @@ public class AuthController {
     /**
      * 로그인
      * POST /auth/login
-     *
+     * <p>
      * 성공: 200 OK + LoginResponse (accessToken, refreshToken, tokenType, expiresIn)
      * 실패: 404 MEMBER_NOT_FOUND    (존재하지 않는 이메일)
-     *       401 INVALID_CREDENTIALS (비밀번호 불일치)
+     * 401 INVALID_CREDENTIALS (비밀번호 불일치)
      */
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
@@ -63,11 +67,11 @@ public class AuthController {
     /**
      * 토큰 재발급 (RT Rotation)
      * POST /auth/refresh
-     *
+     * <p>
      * AT가 만료된 상황에서 호출 → Authorization 헤더 대신 Body로 RT를 전달
      * 성공: 200 OK + LoginResponse (새 AT + 새 RT)
      * 실패: 401 TOKEN_EXPIRED  (RT 만료 — 재로그인 필요)
-     *       401 TOKEN_INVALID  (RT 위변조 or 이미 로그아웃된 상태)
+     * 401 TOKEN_INVALID  (RT 위변조 or 이미 로그아웃된 상태)
      */
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<LoginResponse>> refresh(
@@ -79,20 +83,23 @@ public class AuthController {
     /**
      * 로그아웃
      * POST /auth/logout (🔒 인증 필요)
-     *
+     * <p>
      * 1. AT를 Redis 블랙리스트에 등록 (남은 만료 시간만큼 TTL)
      * 2. Redis에서 RT 삭제 → 이후 재발급 불가
-     *
+     * <p>
      * 성공: 200 OK
      */
-    @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @RequestHeader("Authorization") String authorizationHeader) {
-        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
-            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST);
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request) {
+        // SecurityContext에 저장된 인증 정보를 통해 안전하게 memberId를 전달합니다.
+        // 클라이언트가 보낸 원본 토큰 문자열은 request에서 추출합니다.
+        String accessToken = jwtProvider.resolveToken(request);
+        if (accessToken == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
         }
-        String accessToken = authorizationHeader.substring(BEARER_PREFIX.length());
-        authService.logout(accessToken);
+        authService.logout(userDetails.getMemberId(), accessToken);
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다.", null));
     }
 }
+

--- a/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
@@ -89,6 +89,7 @@ public class AuthController {
      * <p>
      * 성공: 200 OK
      */
+    @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             HttpServletRequest request) {

--- a/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/clone/getchu/domain/auth/controller/AuthController.java
@@ -1,0 +1,98 @@
+package com.clone.getchu.domain.auth.controller;
+
+import com.clone.getchu.domain.auth.dto.LoginRequest;
+import com.clone.getchu.domain.auth.dto.LoginResponse;
+import com.clone.getchu.domain.auth.dto.RefreshRequest;
+import com.clone.getchu.domain.auth.dto.SignupRequest;
+import com.clone.getchu.domain.auth.dto.SignupResponse;
+import com.clone.getchu.domain.auth.service.AuthService;
+import com.clone.getchu.global.common.ApiResponse;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.InvalidRequestException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final AuthService authService;
+
+    /**
+     * 회원가입
+     * POST /auth/signup
+     *
+     * 성공: 201 Created + SignupResponse (id, email, nickname)
+     * 실패: 409 DUPLICATE_EMAIL  (이메일 중복)
+     *       400 INVALID_REQUEST  (@Valid 검증 실패)
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(
+            @Valid @RequestBody SignupRequest request) {
+        SignupResponse response = authService.signup(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+
+    /**
+     * 로그인
+     * POST /auth/login
+     *
+     * 성공: 200 OK + LoginResponse (accessToken, refreshToken, tokenType, expiresIn)
+     * 실패: 404 MEMBER_NOT_FOUND    (존재하지 않는 이메일)
+     *       401 INVALID_CREDENTIALS (비밀번호 불일치)
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 토큰 재발급 (RT Rotation)
+     * POST /auth/refresh
+     *
+     * AT가 만료된 상황에서 호출 → Authorization 헤더 대신 Body로 RT를 전달
+     * 성공: 200 OK + LoginResponse (새 AT + 새 RT)
+     * 실패: 401 TOKEN_EXPIRED  (RT 만료 — 재로그인 필요)
+     *       401 TOKEN_INVALID  (RT 위변조 or 이미 로그아웃된 상태)
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<LoginResponse>> refresh(
+            @Valid @RequestBody RefreshRequest request) {
+        LoginResponse response = authService.refresh(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 로그아웃
+     * POST /auth/logout (🔒 인증 필요)
+     *
+     * 1. AT를 Redis 블랙리스트에 등록 (남은 만료 시간만큼 TTL)
+     * 2. Redis에서 RT 삭제 → 이후 재발급 불가
+     *
+     * 성공: 200 OK
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @RequestHeader("Authorization") String authorizationHeader) {
+        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST);
+        }
+        String accessToken = authorizationHeader.substring(BEARER_PREFIX.length());
+        authService.logout(accessToken);
+        return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다.", null));
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.clone.getchu.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * [로그인 요청 DTO]
+ * POST /auth/login
+ *
+ * 로그인 실패 시 응답 분기:
+ * - 이메일 없음  → 404 MEMBER_NOT_FOUND
+ * - 비밀번호 불일치 → 401 INVALID_CREDENTIALS
+ */
+public record LoginRequest(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/com/clone/getchu/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,23 @@
+package com.clone.getchu.domain.auth.dto;
+
+/**
+ * [로그인 응답 DTO]
+ * POST /auth/login → 200 OK
+ *
+ * - accessToken  : 인증용 JWT (만료 15분)
+ * - refreshToken : 재발급용 JWT (만료 7일), Redis에 서버 측 저장
+ * - tokenType    : 항상 "Bearer"
+ * - expiresIn    : Access Token 유효시간(초)
+ */
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        long expiresIn
+) {
+
+    // tokenType은 항상 "Bearer" 고정 → 호출 편의를 위한 팩토리 메서드
+    public static LoginResponse of(String accessToken, String refreshToken, long accessExpirationMs) {
+        return new LoginResponse(accessToken, refreshToken, "Bearer", accessExpirationMs / 1000);
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/auth/dto/RefreshRequest.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/RefreshRequest.java
@@ -1,0 +1,17 @@
+package com.clone.getchu.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * [토큰 재발급 요청 DTO]
+ * POST /auth/refresh
+ *
+ * Authorization 헤더 대신 Body로 받는 이유:
+ * 재발급 시점에는 AT가 만료된 상태이므로 JwtAuthFilter를 통과할 수 없음.
+ * RT를 Body에 담아 서비스 계층에서 직접 검증한다.
+ */
+public record RefreshRequest(
+
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {}

--- a/src/main/java/com/clone/getchu/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,32 @@
+package com.clone.getchu.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * [회원가입 요청 DTO]
+ * POST /auth/signup
+ *
+ * 유효성 검증:
+ * - email: 이메일 형식 필수
+ * - password: 8자 이상, 영문·숫자·특수문자 각 1자 이상 포함
+ * - nickname: 2~20자
+ */
+public record SignupRequest(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).+$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다.")
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 20, message = "닉네임은 2~20자여야 합니다.")
+        String nickname
+) {}

--- a/src/main/java/com/clone/getchu/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/SignupResponse.java
@@ -1,0 +1,25 @@
+package com.clone.getchu.domain.auth.dto;
+
+import com.clone.getchu.domain.member.entity.Member;
+
+/**
+ * [회원가입 응답 DTO]
+ * POST /auth/signup → 201 Created
+ *
+ * 비밀번호는 응답에서 제외
+ */
+public record SignupResponse(
+        Long id,
+        String email,
+        String nickname
+) {
+
+    // 엔티티 → DTO 변환 (컨트롤러/서비스 계층에서 new SignupResponse(member) 로 호출)
+    public static SignupResponse from(Member member) {
+        return new SignupResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -1,0 +1,162 @@
+package com.clone.getchu.domain.auth.service;
+
+import com.clone.getchu.domain.auth.dto.LoginRequest;
+import com.clone.getchu.domain.auth.dto.LoginResponse;
+import com.clone.getchu.domain.auth.dto.RefreshRequest;
+import com.clone.getchu.domain.auth.dto.SignupRequest;
+import com.clone.getchu.domain.auth.dto.SignupResponse;
+import com.clone.getchu.domain.member.entity.Member;
+import com.clone.getchu.domain.member.repository.MemberRepository;
+import com.clone.getchu.global.exception.ConflictException;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.NotFoundException;
+import com.clone.getchu.global.exception.UnauthorizedException;
+import com.clone.getchu.global.security.JwtProvider;
+import com.clone.getchu.global.util.RedisKeyConstants;
+import com.clone.getchu.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * 회원가입
+     * 1. 이메일 중복 체크 → 409 DUPLICATE_EMAIL
+     * 2. 비밀번호 BCrypt 인코딩
+     * 3. Member 엔티티 생성 후 저장
+     */
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        Member member = Member.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .nickname(request.nickname())
+                .build();
+
+        return SignupResponse.from(memberRepository.save(member));
+    }
+
+    /**
+     * 로그인
+     * 1. 이메일로 회원 조회 → 없으면 404 MEMBER_NOT_FOUND
+     * 2. 비밀번호 BCrypt 검증 → 불일치 시 401 INVALID_CREDENTIALS
+     * 3. AT + RT 발급
+     * 4. RT를 Redis에 저장 (TTL = 7일)
+     *    - 키: "RT:{memberId}" / 기기 1대 기준 → 재로그인 시 이전 RT 자동 덮어쓰기
+     *
+     * [보안 참고] 이메일 존재 여부를 404로 노출하고 있음.
+     * 이메일 열거 공격 방어가 필요하다면 401로 통일 가능.
+     * 현재는 API 명세(06-API 명세서.md)에 따라 구분 응답을 유지함.
+     */
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new UnauthorizedException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtProvider.createAccessToken(
+                member.getId(), member.getEmail(), member.getNickname(), member.getRole().name());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId());
+
+        // RT를 Redis에 저장 — 서버가 RT 유효성을 직접 제어하기 위함
+        String rtKey = RedisKeyConstants.refreshTokenKey(member.getId());
+        stringRedisTemplate.opsForValue().set(
+                rtKey,
+                refreshToken,
+                jwtProvider.getRefreshExpirationTime(),
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponse.of(accessToken, refreshToken, jwtProvider.getAccessExpirationTime());
+    }
+
+    /**
+     * 토큰 재발급 (RT Rotation)
+     * 1. RT 서명·만료 검증 → 실패 시 401
+     * 2. Redis에 저장된 RT와 일치 여부 확인 → 불일치 시 401 (이미 로그아웃 or 재사용 공격)
+     * 3. memberId로 회원 조회 → DB에서 최신 정보 반영
+     * 4. 새 AT + 새 RT 발급 (RT Rotation: 기존 RT 폐기 → 탈취된 RT 재사용 방지)
+     * 5. Redis에 새 RT 저장
+     */
+    @Transactional
+    public LoginResponse refresh(RefreshRequest request) {
+        String oldRefreshToken = request.refreshToken();
+
+        // 1. RT 서명·만료 검증
+        jwtProvider.validateRefreshToken(oldRefreshToken);
+
+        // 2. memberId 추출 후 Redis 저장값과 비교
+        Long memberId = jwtProvider.getMemberIdFromToken(oldRefreshToken);
+        String rtKey = RedisKeyConstants.refreshTokenKey(memberId);
+        String storedToken = stringRedisTemplate.opsForValue().get(rtKey);
+
+        if (storedToken == null || !storedToken.equals(oldRefreshToken)) {
+            throw new UnauthorizedException(ErrorCode.TOKEN_INVALID);
+        }
+
+        // 3. DB에서 최신 회원 정보 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 4. 새 AT + 새 RT 발급
+        String newAccessToken = jwtProvider.createAccessToken(
+                member.getId(), member.getEmail(), member.getNickname(), member.getRole().name());
+        String newRefreshToken = jwtProvider.createRefreshToken(member.getId());
+
+        // 5. Redis에 새 RT 저장 (기존 RT 덮어쓰기 → 기존 RT 사용 불가)
+        stringRedisTemplate.opsForValue().set(
+                rtKey,
+                newRefreshToken,
+                jwtProvider.getRefreshExpirationTime(),
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponse.of(newAccessToken, newRefreshToken, jwtProvider.getAccessExpirationTime());
+    }
+    /**
+     * 로그아웃
+     * 1. AT를 Redis 블랙리스트에 등록 (남은 만료 시간만큼 TTL 설정)
+     *    → JwtAuthFilter에서 매 요청마다 블랙리스트 조회해 차단
+     * 2. Redis에서 RT 삭제 → 이후 재발급 요청 불가
+     *
+     * [참고] AT 만료(15분) 후에는 블랙리스트 키가 자동 삭제되므로 Redis 공간 낭비 없음
+     * [참고] DB 작업 없이 Redis만 사용하므로 @Transactional 미적용
+     */
+    public void logout(String accessToken) {
+        // 1. AT 블랙리스트 등록
+        long remaining = jwtProvider.getRemainingExpiration(accessToken);
+        if (remaining > 0) {
+            String blKey = RedisKeyConstants.blacklistKey(accessToken);
+            stringRedisTemplate.opsForValue().set(
+                    blKey,
+                    "logout",
+                    remaining,
+                    TimeUnit.MILLISECONDS
+            );
+        }
+
+        // 2. RT 삭제
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        stringRedisTemplate.delete(RedisKeyConstants.refreshTokenKey(memberId));
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -117,6 +117,10 @@ public class AuthService {
         String storedToken = stringRedisTemplate.opsForValue().get(rtKey);
 
         if (storedToken == null || !storedToken.equals(oldRefreshToken)) {
+            // [보안] 저장된 토큰과 불일치 → 토큰 탈취 가능성 → 즉시 로그아웃 처리
+            if (storedToken != null) {
+                stringRedisTemplate.delete(rtKey);
+            }
             throw new UnauthorizedException(ErrorCode.TOKEN_INVALID);
         }
 

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -13,7 +13,9 @@ import com.clone.getchu.global.exception.NotFoundException;
 import com.clone.getchu.global.exception.UnauthorizedException;
 import com.clone.getchu.global.security.JwtProvider;
 import com.clone.getchu.global.util.RedisKeyConstants;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -49,7 +51,12 @@ public class AuthService {
                 .nickname(request.nickname())
                 .build();
 
-        return SignupResponse.from(memberRepository.save(member));
+        try {
+            return SignupResponse.from(memberRepository.save(member));
+        } catch (DataIntegrityViolationException e) {
+            // DB Unique 제약조건 위반 시 발생 (동시성 제어의 최후 방어선)
+            throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
+        }
     }
 
     /**
@@ -58,8 +65,8 @@ public class AuthService {
      * 2. 비밀번호 BCrypt 검증 → 불일치 시 401 INVALID_CREDENTIALS
      * 3. AT + RT 발급
      * 4. RT를 Redis에 저장 (TTL = 7일)
-     *    - 키: "RT:{memberId}" / 기기 1대 기준 → 재로그인 시 이전 RT 자동 덮어쓰기
-     *
+     * - 키: "RT:{memberId}" / 기기 1대 기준 → 재로그인 시 이전 RT 자동 덮어쓰기
+     * <p>
      * [보안 참고] 이메일 존재 여부를 404로 노출하고 있음.
      * 이메일 열거 공격 방어가 필요하다면 401로 통일 가능.
      * 현재는 API 명세(06-API 명세서.md)에 따라 구분 응답을 유지함.
@@ -132,16 +139,22 @@ public class AuthService {
 
         return LoginResponse.of(newAccessToken, newRefreshToken, jwtProvider.getAccessExpirationTime());
     }
+
     /**
      * 로그아웃
      * 1. AT를 Redis 블랙리스트에 등록 (남은 만료 시간만큼 TTL 설정)
-     *    → JwtAuthFilter에서 매 요청마다 블랙리스트 조회해 차단
+     * → JwtAuthFilter에서 매 요청마다 블랙리스트 조회해 차단
      * 2. Redis에서 RT 삭제 → 이후 재발급 요청 불가
-     *
+     * <p>
      * [참고] AT 만료(15분) 후에는 블랙리스트 키가 자동 삭제되므로 Redis 공간 낭비 없음
      * [참고] DB 작업 없이 Redis만 사용하므로 @Transactional 미적용
      */
-    public void logout(Long memberId, String accessToken) {
+    public void logout(Long memberId, HttpServletRequest request) {
+        String accessToken = jwtProvider.resolveToken(request);
+        if (accessToken == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+
         long remaining = jwtProvider.getRemainingExpiration(accessToken);
         if (remaining > 0) {
             stringRedisTemplate.opsForValue().set(

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -13,7 +13,6 @@ import com.clone.getchu.global.exception.NotFoundException;
 import com.clone.getchu.global.exception.UnauthorizedException;
 import com.clone.getchu.global.security.JwtProvider;
 import com.clone.getchu.global.util.RedisKeyConstants;
-import com.clone.getchu.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -86,7 +85,7 @@ public class AuthService {
                 jwtProvider.getRefreshExpirationTime(),
                 TimeUnit.MILLISECONDS
         );
-
+        // @Value로 주입받던 방식 -> JwtProvider에서 가져오는 방식
         return LoginResponse.of(accessToken, refreshToken, jwtProvider.getAccessExpirationTime());
     }
 
@@ -142,21 +141,17 @@ public class AuthService {
      * [참고] AT 만료(15분) 후에는 블랙리스트 키가 자동 삭제되므로 Redis 공간 낭비 없음
      * [참고] DB 작업 없이 Redis만 사용하므로 @Transactional 미적용
      */
-    public void logout(String accessToken) {
-        // 1. AT 블랙리스트 등록
+    public void logout(Long memberId, String accessToken) {
         long remaining = jwtProvider.getRemainingExpiration(accessToken);
         if (remaining > 0) {
-            String blKey = RedisKeyConstants.blacklistKey(accessToken);
             stringRedisTemplate.opsForValue().set(
-                    blKey,
+                    RedisKeyConstants.blacklistKey(accessToken),
                     "logout",
                     remaining,
                     TimeUnit.MILLISECONDS
             );
         }
-
-        // 2. RT 삭제
-        Long memberId = SecurityUtil.getCurrentMemberId();
+        // SecurityUtil 대신 파라미터로 받은 memberId 사용
         stringRedisTemplate.delete(RedisKeyConstants.refreshTokenKey(memberId));
     }
 }

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -146,16 +146,21 @@ public class AuthService {
      * → JwtAuthFilter에서 매 요청마다 블랙리스트 조회해 차단
      * 2. Redis에서 RT 삭제 → 이후 재발급 요청 불가
      * <p>
-     * [참고] AT 만료(15분) 후에는 블랙리스트 키가 자동 삭제되므로 Redis 공간 낭비 없음
+     * [참고] AT 유효성 검증 및 남은 만료 시간 계산은 JwtAuthFilter에서 선행 처리됨.
+     * 서비스 계층은 필터가 request 속성("jwt.token", "jwt.remaining")으로 전달한 값을 그대로 사용해
+     * 조작·만료 토큰에 대한 재파싱 예외 위험을 제거함.
+     * [참고] AT 만료 후 블랙리스트 키가 자동 삭제되므로 Redis 공간 낭비 없음
      * [참고] DB 작업 없이 Redis만 사용하므로 @Transactional 미적용
      */
     public void logout(Long memberId, HttpServletRequest request) {
-        String accessToken = jwtProvider.resolveToken(request);
-        if (accessToken == null) {
+        // JwtAuthFilter가 검증 후 저장한 속성에서 토큰과 남은 만료 시간을 읽음
+        String accessToken = (String) request.getAttribute("jwt.token");
+        Long remaining = (Long) request.getAttribute("jwt.remaining");
+
+        if (accessToken == null || remaining == null) {
             throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
         }
 
-        long remaining = jwtProvider.getRemainingExpiration(accessToken);
         if (remaining > 0) {
             stringRedisTemplate.opsForValue().set(
                     RedisKeyConstants.blacklistKey(accessToken),
@@ -164,7 +169,6 @@ public class AuthService {
                     TimeUnit.MILLISECONDS
             );
         }
-        // SecurityUtil 대신 파라미터로 받은 memberId 사용
         stringRedisTemplate.delete(RedisKeyConstants.refreshTokenKey(memberId));
     }
 }

--- a/src/main/java/com/clone/getchu/domain/member/controller/MemberController.java
+++ b/src/main/java/com/clone/getchu/domain/member/controller/MemberController.java
@@ -1,0 +1,13 @@
+package com.clone.getchu.domain.member.controller;
+
+import com.clone.getchu.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/me")
+public class MemberController {
+    private final MemberService memberService;
+}

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -7,12 +7,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 @Entity
 @Table(name = "members")
+@SQLRestriction("deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member extends BaseEntity {
@@ -62,11 +64,12 @@ public class Member extends BaseEntity {
 
     // TODO Review 도메인 추가 구현 예정
     public void updateReviewStats(int newRating) {
-        // 새 평균=(기존 평균 * 기존 리뷰 수 + 새 별점) / (기존 리뷰 수 + 1)
+        // 새 평균 = (기존 평균 * 기존 리뷰 수 + 새 별점) / (기존 리뷰 수 + 1)
+        // reviewCount는 계산 후 증가시키므로 현재 값이 곧 "기존 리뷰 수"
         BigDecimal newAvg = this.averageRating
-                .multiply(BigDecimal.valueOf(this.reviewCount - 1))
+                .multiply(BigDecimal.valueOf(this.reviewCount))
                 .add(BigDecimal.valueOf(newRating))
-                .divide(BigDecimal.valueOf(this.reviewCount), 1, RoundingMode.HALF_UP);
+                .divide(BigDecimal.valueOf(this.reviewCount + 1), 1, RoundingMode.HALF_UP);
         this.averageRating = newAvg;
         this.reviewCount++;
     }

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -1,0 +1,66 @@
+package com.clone.getchu.domain.member.entity;
+
+import com.clone.getchu.domain.member.enums.MemberRole;
+import com.clone.getchu.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    // 리뷰 평균 별점 (비정규화)
+    // 리뷰 작성 시 단일 트랜잭션 내에서 함께 UPDATE
+    @Column(nullable = false)
+    private double averageRating = 0.0;
+    @Column(nullable = false)
+    private int reviewCount = 0;
+
+    // 회원 권한 (현재 USER 단일값, 추후 ADMIN 확장 가능)
+    // DB에 "USER", "ADMIN" 형태로 저장 (ROLE_ 접두사 없이)
+    // CustomUserDetails에서 "ROLE_" + role 형태로 변환
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role = MemberRole.USER;
+
+    // 회원 탈퇴 여부 (소프트 삭제)
+    // true = 탈퇴한 회원, 목록/검색에서 제외
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    @Builder
+    private Member(String email, String password, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.averageRating = 0.0;
+        this.reviewCount = 0;
+        this.role = MemberRole.USER;
+        this.deleted = false;
+    }
+
+    // TODO Review 도메인 추가 구현 예정
+    public void updateReviewStats(int newRating) {
+        // 새 평균=(기존 평균 * 기존 리뷰 수 + 새 별점) / (기존 리뷰 수 + 1)
+        this.averageRating = (this.averageRating * this.reviewCount + newRating)
+                / (this.reviewCount + 1);
+        this.reviewCount++;
+    }
+
+}

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Entity
 @Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,8 +30,9 @@ public class Member extends BaseEntity {
 
     // 리뷰 평균 별점 (비정규화)
     // 리뷰 작성 시 단일 트랜잭션 내에서 함께 UPDATE
-    @Column(nullable = false)
-    private double averageRating = 0.0;
+    // DECIMAL(2,1): 부동소수점 오차 방지, 소수점 1자리 반올림 저장
+    @Column(nullable = false, precision = 2, scale = 1)
+    private BigDecimal averageRating = BigDecimal.ZERO;
     @Column(nullable = false)
     private int reviewCount = 0;
 
@@ -49,7 +53,7 @@ public class Member extends BaseEntity {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.averageRating = 0.0;
+        this.averageRating = BigDecimal.ZERO;
         this.reviewCount = 0;
         this.role = MemberRole.USER;
         this.deleted = false;
@@ -58,8 +62,11 @@ public class Member extends BaseEntity {
     // TODO Review 도메인 추가 구현 예정
     public void updateReviewStats(int newRating) {
         // 새 평균=(기존 평균 * 기존 리뷰 수 + 새 별점) / (기존 리뷰 수 + 1)
-        this.averageRating = (this.averageRating * this.reviewCount + newRating)
-                / (this.reviewCount + 1);
+        BigDecimal newAvg = this.averageRating
+                .multiply(BigDecimal.valueOf(this.reviewCount))
+                .add(BigDecimal.valueOf(newRating))
+                .divide(BigDecimal.valueOf(this.reviewCount + 1), 1, RoundingMode.HALF_UP);
+        this.averageRating = newAvg;
         this.reviewCount++;
     }
 

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -16,7 +16,8 @@ import java.math.RoundingMode;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true)
@@ -63,11 +64,10 @@ public class Member extends BaseEntity {
     public void updateReviewStats(int newRating) {
         // 새 평균=(기존 평균 * 기존 리뷰 수 + 새 별점) / (기존 리뷰 수 + 1)
         BigDecimal newAvg = this.averageRating
-                .multiply(BigDecimal.valueOf(this.reviewCount))
+                .multiply(BigDecimal.valueOf(this.reviewCount - 1))
                 .add(BigDecimal.valueOf(newRating))
-                .divide(BigDecimal.valueOf(this.reviewCount + 1), 1, RoundingMode.HALF_UP);
+                .divide(BigDecimal.valueOf(this.reviewCount), 1, RoundingMode.HALF_UP);
         this.averageRating = newAvg;
         this.reviewCount++;
     }
-
 }

--- a/src/main/java/com/clone/getchu/domain/member/enums/MemberRole.java
+++ b/src/main/java/com/clone/getchu/domain/member/enums/MemberRole.java
@@ -1,0 +1,6 @@
+package com.clone.getchu.domain.member.enums;
+
+public enum MemberRole {
+    USER, // 일반 회원 (구매자/판매자 모두)
+    ADMIN   // 추후 확장용 (현재 미사용)
+}

--- a/src/main/java/com/clone/getchu/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/clone/getchu/domain/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.clone.getchu.domain.member.repository;
+
+import com.clone.getchu.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // 로그인 시 이메일로 회원 조회
+    Optional<Member> findByEmail(String email);
+
+    // 회원가입 시 이메일 중복 체크
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
+++ b/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
@@ -1,0 +1,13 @@
+package com.clone.getchu.domain.member.service;
+
+import com.clone.getchu.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+    private final MemberRepository memberRepository;
+}

--- a/src/main/java/com/clone/getchu/global/common/ApiResponse.java
+++ b/src/main/java/com/clone/getchu/global/common/ApiResponse.java
@@ -9,20 +9,23 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 
+    private static final String SUCCESS_CODE = "SUCCESS";
+    private static final String SUCCESS_MESSAGE = "요청이 성공적으로 처리되었습니다.";
+
     private final String code;
     private final String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;
 
     public static <T> ApiResponse<T> success() {
-        return new ApiResponse<>("SUCCESS", "요청이 성공적으로 처리되었습니다.", null);
+        return new ApiResponse<>(SUCCESS_CODE, SUCCESS_MESSAGE, null);
     }
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>("SUCCESS", "요청이 성공적으로 처리되었습니다.", data);
+        return new ApiResponse<>(SUCCESS_CODE, SUCCESS_MESSAGE, data);
     }
 
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>("SUCCESS", message, data);
+        return new ApiResponse<>(SUCCESS_CODE, message, data);
     }
 }

--- a/src/main/java/com/clone/getchu/global/common/BaseEntity.java
+++ b/src/main/java/com/clone/getchu/global/common/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.clone.getchu.global.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/clone/getchu/global/common/ErrorResponse.java
+++ b/src/main/java/com/clone/getchu/global/common/ErrorResponse.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.validation.FieldError;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Getter
@@ -24,7 +24,7 @@ public class ErrorResponse {
     private ErrorResponse(String code, String message) {
         this.code = code;
         this.message = message;
-        this.timestamp = LocalDateTime.now().toString();
+        this.timestamp = Instant.now().toString();
     }
 
     // 일반 비즈니스 예외 - ErrorCode에 정의된 기본 메시지 사용

--- a/src/main/java/com/clone/getchu/global/config/CacheConfig.java
+++ b/src/main/java/com/clone/getchu/global/config/CacheConfig.java
@@ -13,12 +13,17 @@ import java.util.concurrent.TimeUnit;
 @EnableCaching
 public class CacheConfig {
 
+    public static final String POPULAR_KEYWORDS = "popularKeywords";
+    private static final int POPULAR_KEYWORDS_TTL_MINUTES = 10;
+    // 검색어 순위는 전체 목록을 하나의 값으로 캐싱하므로 최대 1개 엔트리로 충분
+    private static final int POPULAR_KEYWORDS_MAX_SIZE = 1;
+
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("popularKeywords");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(POPULAR_KEYWORDS);
         cacheManager.setCaffeine(Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
-                .maximumSize(1));
+                .expireAfterWrite(POPULAR_KEYWORDS_TTL_MINUTES, TimeUnit.MINUTES)
+                .maximumSize(POPULAR_KEYWORDS_MAX_SIZE));
         return cacheManager;
     }
 }

--- a/src/main/java/com/clone/getchu/global/config/SecurityConfig.java
+++ b/src/main/java/com/clone/getchu/global/config/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
             )
             
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/signup", "/auth/login").permitAll()
+                // /auth/refresh: AT가 만료된 상태에서 호출되므로 인증 없이 허용
+                .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
                 .requestMatchers(HttpMethod.GET, "/products", "/products/**", "/categories", "/search/popular").permitAll()
                 .requestMatchers(HttpMethod.GET, "/members/*/reviews").permitAll()
                 .requestMatchers("/ws-chat/**").permitAll()

--- a/src/main/java/com/clone/getchu/global/config/WebConfig.java
+++ b/src/main/java/com/clone/getchu/global/config/WebConfig.java
@@ -1,19 +1,12 @@
 package com.clone.getchu.global.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * CORS 설정은 SecurityConfig.corsConfigurationSource() 에서 단일 관리합니다.
+ * Spring Security 필터 체인이 활성화된 경우 WebMvcConfigurer.addCorsMappings()는
+ * 인증이 필요한 요청에 적용되지 않으므로 SecurityConfig의 설정이 권위적입니다.
+ */
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOriginPatterns("*") // 추후 배포 환경에 맞게 수정
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3600);
-    }
+public class WebConfig {
 }

--- a/src/main/java/com/clone/getchu/global/exception/ErrorCode.java
+++ b/src/main/java/com/clone/getchu/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A003", "인증이 필요합니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A004", "토큰이 만료되었습니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "A005", "유효하지 않은 토큰입니다."),
+    LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED, "A006", "로그아웃된 토큰입니다."),
 
     // ===== MEMBER (M) =====
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),

--- a/src/main/java/com/clone/getchu/global/exception/LockTimeoutException.java
+++ b/src/main/java/com/clone/getchu/global/exception/LockTimeoutException.java
@@ -1,7 +1,11 @@
 package com.clone.getchu.global.exception;
 
 public class LockTimeoutException extends ConflictException {
+
+    // 분산락 획득 실패 시 클라이언트에게 안내하는 재시도 권장 시간 (초)
+    private static final int RETRY_AFTER_SECONDS = 1;
+
     public LockTimeoutException() {
-        super(ErrorCode.LOCK_TIMEOUT, 1);
+        super(ErrorCode.LOCK_TIMEOUT, RETRY_AFTER_SECONDS);
     }
 }

--- a/src/main/java/com/clone/getchu/global/security/CustomUserDetails.java
+++ b/src/main/java/com/clone/getchu/global/security/CustomUserDetails.java
@@ -1,0 +1,95 @@
+package com.clone.getchu.global.security;
+
+import com.clone.getchu.domain.member.enums.MemberRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * [Spring Security 인증 주체] JWT 클레임을 Security가 이해하는 형식으로 래핑
+ * <p>
+ * Spring Security는 인증된 사용자 정보를 UserDetails 인터페이스로 다룹니다.
+ * DB를 조회하지 않고 JWT 클레임(memberId, email, role)만으로 객체를 구성합니다.
+ * <p>
+ * 사용 흐름:
+ * 1. JwtProvider.getAuthentication() 에서 JWT 파싱 후 이 객체 생성
+ * 2. JwtAuthFilter가 SecurityContext에 저장
+ * 3. 컨트롤러에서 @AuthenticationPrincipal CustomUserDetails userDetails 로 꺼냄
+ * 또는 SecurityUtil.getCurrentMemberId() 로 memberId만 꺼냄
+ */
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Long memberId;  // DB PK, 비즈니스 로직에서 주로 사용
+    private final String email;// JWT subject 필드
+    private final String nickname;
+    private final String role;    // 예: "USER", "ADMIN" (DB에 저장된 값 그대로)
+
+    /**
+     * Spring Security 권한 반환
+     * role이 "USER"이면 → "ROLE_USER" 로 변환해서 반환
+     * <p>
+     * [주의사항]
+     * - DB에 "USER"로 저장 → "ROLE_USER" 자동 변환 (정상)
+     * - DB에 "ROLE_USER"로 저장 → "ROLE_ROLE_USER" 이중 접두사 문제 발생
+     * → Member 엔티티의 role 컬럼에는 반드시 "ROLE_" 없이 저장할 것
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+        // return Collections.singletonList 보다 List.of 가 코드가 더 짧고 직관적이며 null 값을 허용하지않아 더 안전
+    }
+
+    /**
+     * JWT 방식에서는 비밀번호 검증이 필요 없으므로 null 반환
+     * 실제 비밀번호 검증은 로그인 시 BCrypt로 처리
+     */
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    /**
+     * Security에서 "사용자 이름"으로 쓰이는 필드
+     * 이 프로젝트에서는 email을 식별자로 사용
+     */
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    /**
+     * 아래 4개는 계정 상태 체크 메서드
+     * Stateless JWT 방식에서는 모두 true로 고정
+     * 계정 잠금/만료 같은 상태 관리는 JWT 자체 만료(exp 클레임)로 대신함
+     * <p>
+     * [추후 확장 포인트]
+     * - 계정 정지 기능 추가 시 isEnabled()에서 Member.isActive 필드 체크
+     * - 비밀번호 변경 후 기존 토큰 무효화 필요 시 isCredentialsNonExpired() 활용
+     */
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/clone/getchu/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package com.clone.getchu.global.security;
+
+import com.clone.getchu.global.common.ErrorResponse;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * [인가 실패 핸들러] HTTP 403 Forbidden 응답 담당
+ *
+ * 토큰은 있지만 해당 API에 대한 권한이 없을 때 Spring Security가 이 클래스를 호출합니다.
+ * 예) USER 권한으로 ADMIN 전용 API 접근 시
+ *
+ * SecurityConfig에서 .accessDeniedHandler(jwtAccessDeniedHandler) 로 등록됩니다.
+ *
+ * [JwtAuthEntryPoint와 차이]
+ * - JwtAuthEntryPoint      → 401 (인증 실패 - 토큰 없음/만료/서명 오류)
+ * - JwtAccessDeniedHandler → 403 (인가 실패 - 토큰은 있지만 권한 없음)
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException e) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(ErrorCode.FORBIDDEN.getHttpStatus().value());
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.FORBIDDEN)));
+    }
+}

--- a/src/main/java/com/clone/getchu/global/security/JwtAuthEntryPoint.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtAuthEntryPoint.java
@@ -1,0 +1,42 @@
+package com.clone.getchu.global.security;
+
+import com.clone.getchu.global.common.ErrorResponse;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * [인증 실패 핸들러] HTTP 401 Unauthorized 응답 담당
+ *
+ * 로그인 자체가 안 된 상태(토큰 없음, 만료, 서명 불일치)로
+ * 인증이 필요한 API에 접근했을 때 Spring Security가 이 클래스를 호출합니다.
+ *
+ * SecurityConfig에서 .authenticationEntryPoint(jwtAuthEntryPoint) 로 등록됩니다.
+ *
+ * [ErrorCode 활용]
+ * 하드코딩("A003", "인증이 필요합니다.") 대신 ErrorCode.UNAUTHORIZED를 참조해서
+ * 에러코드 변경 시 한 곳(ErrorCode)에서만 수정하면 되도록 일관성을 유지합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException e)
+            throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(ErrorCode.UNAUTHORIZED.getHttpStatus().value());
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.UNAUTHORIZED)));
+    }
+}

--- a/src/main/java/com/clone/getchu/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtAuthFilter.java
@@ -62,8 +62,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         try {
             // validateToken() 은 예외를 내부에서 swallow하므로 만료/무효 구분이 불가.
             // validateTokenOrThrow() 로 예외를 전파받아 정확한 에러코드를 반환한다.
-            // 로그아웃된 토큰(블랙리스트) 차단 — Redis에 "BL:{token}" 키 존재 여부 확인
             jwtProvider.validateTokenOrThrow(jwt);
+
+            // 로그아웃된 토큰(블랙리스트) 차단 — Redis에 "BL:{token}" 키 존재 여부 확인
             if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(RedisKeyConstants.blacklistKey(jwt)))) {
                 log.warn("블랙리스트 처리된 Access Token입니다. code={}, message={}",
                         ErrorCode.LOGGED_OUT_TOKEN.getCode(),
@@ -71,6 +72,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 writeErrorResponse(response, ErrorCode.LOGGED_OUT_TOKEN);
                 return;
             }
+
+            // 남은 만료 시간을 request 속성으로 저장 — logout 시 서비스 계층에서 재파싱 없이 사용
+            long remaining = jwtProvider.getRemainingExpiration(jwt);
+            request.setAttribute("jwt.token", jwt);
+            request.setAttribute("jwt.remaining", remaining);
 
             Authentication authentication = jwtProvider.getAuthentication(jwt);
             // SecurityContext에 인증 정보 저장 - 이후 요청 처리 동안 어디서든 꺼낼 수 있음

--- a/src/main/java/com/clone/getchu/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtAuthFilter.java
@@ -1,0 +1,149 @@
+package com.clone.getchu.global.security;
+
+import com.clone.getchu.global.common.ErrorResponse;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import com.clone.getchu.global.util.RedisKeyConstants;
+
+import java.io.IOException;
+
+/**
+ * [JWT 인증 필터] 모든 HTTP 요청에서 토큰을 추출해 인증 처리
+ * <p>
+ * OncePerRequestFilter를 상속해서 하나의 요청에 딱 한 번만 실행됩니다.
+ * SecurityConfig에서 UsernamePasswordAuthenticationFilter 앞에 등록되어
+ * 요청이 컨트롤러에 도달하기 전에 JWT를 검사합니다.
+ * <p>
+ * 처리 흐름:
+ * 1. Authorization 헤더에서 Bearer 토큰 추출
+ * 2. JWT 유효성 검증
+ * 3. Redis 블랙리스트 토큰인지 확인
+ * 4. 정상 토큰이면 Authentication 생성 후 SecurityContext 저장
+ * 5. 토큰이 없으면 다음 필터로 넘김
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String jwt = resolveToken(request);
+
+        // JWT가 없는 경우:
+        // - 인증 정보가 없는 요청으로 처리
+        // - SecurityContext를 설정하지 않고 다음 필터로 넘김
+        // - 인증이 필요한 API라면 이후 Security가 401 응답 처리
+        if (!StringUtils.hasText(jwt)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        try {
+            // validateToken() 은 예외를 내부에서 swallow하므로 만료/무효 구분이 불가.
+            // validateTokenOrThrow() 로 예외를 전파받아 정확한 에러코드를 반환한다.
+            jwtProvider.validateTokenOrThrow(jwt);
+
+            // 로그아웃된 토큰(블랙리스트) 차단 — Redis에 "BL:{token}" 키 존재 여부 확인
+            if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(RedisKeyConstants.blacklistKey(jwt)))) {
+                log.warn("블랙리스트 처리된 Access Token입니다. code={}, message={}",
+                        ErrorCode.LOGGED_OUT_TOKEN.getCode(),
+                        ErrorCode.LOGGED_OUT_TOKEN.getMessage());
+                writeErrorResponse(response, ErrorCode.LOGGED_OUT_TOKEN);
+                return;
+            }
+
+            Authentication authentication = jwtProvider.getAuthentication(jwt);
+            // SecurityContext에 인증 정보 저장 - 이후 요청 처리 동안 어디서든 꺼낼 수 있음
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (SecurityException | MalformedJwtException e) {
+            log.warn("유효하지 않은 JWT 서명입니다. code={}, message={}",
+                    ErrorCode.TOKEN_INVALID.getCode(),
+                    ErrorCode.TOKEN_INVALID.getMessage(),
+                    e);
+            writeErrorResponse(response, ErrorCode.TOKEN_INVALID);
+            return;
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다. code={}, message={}",
+                    ErrorCode.TOKEN_EXPIRED.getCode(),
+                    ErrorCode.TOKEN_EXPIRED.getMessage(),
+                    e);
+            writeErrorResponse(response, ErrorCode.TOKEN_EXPIRED);
+            return;
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다. code={}, message={}",
+                    ErrorCode.TOKEN_INVALID.getCode(),
+                    ErrorCode.TOKEN_INVALID.getMessage(),
+                    e);
+            writeErrorResponse(response, ErrorCode.TOKEN_INVALID, "지원되지 않는 JWT 토큰입니다.");
+            return;
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT claims가 비어있습니다. code={}, message={}",
+                    ErrorCode.TOKEN_INVALID.getCode(),
+                    ErrorCode.TOKEN_INVALID.getMessage(),
+                    e);
+            writeErrorResponse(response, ErrorCode.TOKEN_INVALID, "잘못된 JWT 토큰입니다.");
+            return;
+        }
+        // 현재 코드는 유효하지 않으면 이미 return으로 처리함
+        // 여기 도달하는 건 "정상 토큰" 또는 "토큰 없음" 두 경우뿐
+        // 정상 처리 완료 후 다음 필터로 넘김
+        filterChain.doFilter(request, response);
+    }
+
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰을 추출한다.
+     *
+     * @param request HTTP 요청
+     * @return 순수 JWT 문자열, 없거나 형식이 잘못되면 null
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        writeErrorResponse(response, ErrorResponse.of(errorCode), errorCode.getHttpStatus().value());
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String detailMessage) throws IOException {
+        writeErrorResponse(response, ErrorResponse.of(errorCode, detailMessage), errorCode.getHttpStatus().value());
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorResponse errorResponse, int status) throws IOException {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/clone/getchu/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtAuthFilter.java
@@ -42,9 +42,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
@@ -53,8 +50,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String jwt = resolveToken(request);
-
+        String jwt = jwtProvider.resolveToken(request);
         // JWT가 없는 경우:
         // - 인증 정보가 없는 요청으로 처리
         // - SecurityContext를 설정하지 않고 다음 필터로 넘김
@@ -66,9 +62,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         try {
             // validateToken() 은 예외를 내부에서 swallow하므로 만료/무효 구분이 불가.
             // validateTokenOrThrow() 로 예외를 전파받아 정확한 에러코드를 반환한다.
-            jwtProvider.validateTokenOrThrow(jwt);
-
             // 로그아웃된 토큰(블랙리스트) 차단 — Redis에 "BL:{token}" 키 존재 여부 확인
+            jwtProvider.validateTokenOrThrow(jwt);
             if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(RedisKeyConstants.blacklistKey(jwt)))) {
                 log.warn("블랙리스트 처리된 Access Token입니다. code={}, message={}",
                         ErrorCode.LOGGED_OUT_TOKEN.getCode(),
@@ -114,22 +109,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // 여기 도달하는 건 "정상 토큰" 또는 "토큰 없음" 두 경우뿐
         // 정상 처리 완료 후 다음 필터로 넘김
         filterChain.doFilter(request, response);
-    }
-
-
-    /**
-     * Authorization 헤더에서 Bearer 토큰을 추출한다.
-     *
-     * @param request HTTP 요청
-     * @return 순수 JWT 문자열, 없거나 형식이 잘못되면 null
-     */
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(BEARER_PREFIX.length());
-        }
-        return null;
     }
 
     private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {

--- a/src/main/java/com/clone/getchu/global/security/JwtProvider.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtProvider.java
@@ -8,11 +8,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -165,7 +167,17 @@ public class JwtProvider {
         }
         return false;
     }
-
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     * JwtAuthFilter, AuthController(로그아웃)에서 공통으로 사용
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
     /**
      * 토큰에서 클레임 추출
      * 만료된 토큰이라도 클레임 자체는 읽을 수 있어서 ExpiredJwtException 별도 처리

--- a/src/main/java/com/clone/getchu/global/security/JwtProvider.java
+++ b/src/main/java/com/clone/getchu/global/security/JwtProvider.java
@@ -1,0 +1,186 @@
+package com.clone.getchu.global.security;
+
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * [JWT 핵심 유틸리티] 토큰 생성 / 파싱 / 검증 담당
+ * <p>
+ * Access Token  : 15분 만료, 인증 클레임(memberId·email·nickname·role) 포함
+ * Refresh Token : 7일 만료, subject(memberId)만 포함 — Redis에 저장해 서버가 직접 관리
+ */
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+    private final long accessExpirationTime;
+    private final long refreshExpirationTime;
+
+    public JwtProvider(
+            @Value("${jwt.secret-key}") String secretKey,
+            @Value("${jwt.access-expiration-time}") long accessExpirationTime,
+            @Value("${jwt.refresh-expiration-time}") long refreshExpirationTime) {
+        // 플랫폼 기본 인코딩 대신 UTF-8을 명시해서 환경(OS/JVM)에 상관없이 동일한 키를 생성
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessExpirationTime = accessExpirationTime;
+        this.refreshExpirationTime = refreshExpirationTime;
+    }
+
+    public long getAccessExpirationTime() {
+        return accessExpirationTime;
+    }
+
+    public long getRefreshExpirationTime() {
+        return refreshExpirationTime;
+    }
+
+    // 로그인 성공 시 호출 - memberId, email, role을 JWT 클레임에 담아 토큰 생성
+    public String createAccessToken(Long memberId, String email, String nickname, String role) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + accessExpirationTime);
+
+        return Jwts.builder()
+                .subject(email)
+                .claim("memberId", memberId)
+                .claim("nickname", nickname) // 채팅방 등에서 DB 조회 없이 닉네임 표시용
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(key) // 알고리즘 자동 감지 → 알고리즘 혼동 공격 방지
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성
+     * AT와 달리 subject(memberId)만 담음 — 인증 클레임 불필요, 만료 시간만 길게 설정
+     * 실제 유효성은 Redis 저장 여부로 추가 검증 (validateRefreshToken 참고)
+     */
+    public String createRefreshToken(Long memberId) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + refreshExpirationTime);
+
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Refresh Token에서 memberId 추출
+     * RT는 subject에 memberId만 저장하므로 파싱 후 Long 변환
+     */
+    public Long getMemberIdFromToken(String token) {
+        return Long.parseLong(parseClaims(token).getSubject());
+    }
+
+    /**
+     * 토큰의 남은 유효시간(ms) 반환
+     * AT 블랙리스트 등록 시 Redis TTL 계산에 사용
+     */
+    public long getRemainingExpiration(String token) {
+        long expiry = parseClaims(token).getExpiration().getTime();
+        long remaining = expiry - System.currentTimeMillis();
+        return Math.max(remaining, 0);
+    }
+
+    /**
+     * Refresh Token 유효성 검증 — 실패 시 예외를 직접 던짐
+     * validateToken()과 달리 호출부에서 분기 처리 없이 바로 쓸 수 있음
+     */
+    public void validateRefreshToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(ErrorCode.TOKEN_EXPIRED);
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorCode.TOKEN_INVALID);
+        }
+    }
+
+    /**
+     * Access Token 유효성 검증 — 실패 시 예외를 직접 던짐 (JwtAuthFilter 전용)
+     * validateToken()과 달리 예외를 호출부로 전파해서 정확한 에러 코드 반환을 가능하게 함
+     */
+    public void validateTokenOrThrow(String token) {
+        Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+    }
+
+    // 유효한 토큰에서 인증 객체 생성 - JwtAuthFilter, StompChannelInterceptor에서 호출
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        Long memberId = claims.get("memberId", Long.class);
+        String email = claims.getSubject();
+        String nickname = claims.get("nickname", String.class);
+        String role = claims.get("role", String.class);
+
+        // DB 조회 없이 클레임만으로 CustomUserDetails 생성
+        CustomUserDetails userDetails = new CustomUserDetails(memberId, email, nickname, role);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    /**
+     * 토큰의 서명, 만료 여부 등을 검증
+     * true면 유효, false면 무효
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("유효하지않은 JWT 서명입니다. - {}", ErrorCode.TOKEN_INVALID.getMessage(), e);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다. - {}", ErrorCode.TOKEN_EXPIRED.getMessage(), e);
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다. - {}", ErrorCode.TOKEN_INVALID.getMessage(), e);
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT claims가 비어있습니다. - {}", ErrorCode.TOKEN_INVALID.getMessage(), e);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 클레임 추출
+     * 만료된 토큰이라도 클레임 자체는 읽을 수 있어서 ExpiredJwtException 별도 처리
+     * validateToken()에서 이미 검증 통과한 토큰만 여기 도달하므로 다른 예외는 사실상 발생 안 함
+     */
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(accessToken)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            // 만료됐어도 클레임은 읽을 수 있음(방어적 코드)
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/clone/getchu/global/security/StompChannelInterceptor.java
+++ b/src/main/java/com/clone/getchu/global/security/StompChannelInterceptor.java
@@ -1,0 +1,72 @@
+package com.clone.getchu.global.security;
+
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.UnauthorizedException;
+import com.clone.getchu.global.util.RedisKeyConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * [WebSocket JWT 인증 인터셉터] STOMP 연결 시 토큰 검증
+ *
+ * HTTP 요청은 JwtAuthFilter가 처리하지만, WebSocket은 최초 연결(Upgrade) 이후
+ * HTTP 필터 체인을 거치지 않습니다. 그래서 WebSocket 전용 인증 처리가 필요합니다.
+ *
+ * WebSocketConfig에서 configureClientInboundChannel()로 등록되어
+ * 클라이언트 → 서버 방향의 모든 STOMP 메시지 전송 전에 실행됩니다.
+ *
+ * 클라이언트는 연결 시 아래와 같이 토큰을 전달해야 합니다:
+ * STOMP CONNECT 헤더: { Authorization: "Bearer {AccessToken}" }
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompChannelInterceptor implements ChannelInterceptor {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // 메시지가 채널로 전송되기 직전에 호출됨
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        // CONNECT 명령일 때만 검증 - SEND, SUBSCRIBE 등 이후 메시지는 세션에 user가 이미 설정됨
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+            if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+                throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+            }
+
+            String token = authHeader.substring(BEARER_PREFIX.length());
+
+            if (!jwtProvider.validateToken(token)) {
+                throw new UnauthorizedException(ErrorCode.TOKEN_INVALID);
+            }
+
+            // 로그아웃된 토큰(블랙리스트) 차단 — HTTP 필터와 동일한 기준 적용
+            if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(RedisKeyConstants.blacklistKey(token)))) {
+                throw new UnauthorizedException(ErrorCode.LOGGED_OUT_TOKEN);
+            }
+
+            Authentication auth = jwtProvider.getAuthentication(token);
+            // STOMP 세션에 인증 정보 등록 - 이후 convertAndSendToUser() 시 이 user 정보를 사용해 라우팅
+            accessor.setUser(auth);
+            log.debug("WebSocket CONNECT 인증 성공 - user: {}", auth.getName());
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/clone/getchu/global/util/CursorUtil.java
+++ b/src/main/java/com/clone/getchu/global/util/CursorUtil.java
@@ -11,11 +11,11 @@ public class CursorUtil {
 
     public static String encodeCursor(String rawCursor) {
         if (rawCursor == null) return null;
-        return Base64.getEncoder().encodeToString(rawCursor.getBytes(StandardCharsets.UTF-8));
+        return Base64.getEncoder().encodeToString(rawCursor.getBytes(StandardCharsets.UTF_8));
     }
 
     public static String decodeCursor(String encodedCursor) {
         if (encodedCursor == null) return null;
-        return new String(Base64.getDecoder().decode(encodedCursor), StandardCharsets.UTF-8);
+        return new String(Base64.getDecoder().decode(encodedCursor), StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/clone/getchu/global/util/RedisKeyConstants.java
+++ b/src/main/java/com/clone/getchu/global/util/RedisKeyConstants.java
@@ -1,0 +1,39 @@
+package com.clone.getchu.global.util;
+/**
+ * Redis 키 접두사 상수 및 키 생성 메서드 관리
+ *
+ * [키 설계]
+ * - RT:{memberId}    : Refresh Token 저장 (TTL = 7일)
+ * - BL:{accessToken} : 로그아웃된 AT 블랙리스트 (TTL = AT 남은 만료시간)
+ *
+ * [키 생성 메서드를 두는 이유]
+ * - 호출부에서 PREFIX + 값 연결 코드 제거 → 가독성 향상
+ * - 키 형식 변경 시 이 클래스만 수정하면 됨 → 유지보수 용이
+ */
+public final class RedisKeyConstants {
+
+    private RedisKeyConstants() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    // Refresh Token: "RT:{memberId}"
+    private static final String RT_PREFIX = "RT:";
+
+    // Access Token 블랙리스트: "BL:{accessToken}"
+    private static final String BL_PREFIX = "BL:";
+    /**
+     * Refresh Token Redis 키 생성
+     * 예: refreshTokenKey(1L) → "RT:1"
+     */
+    public static String refreshTokenKey(Long memberId) {
+        return RT_PREFIX + memberId;
+    }
+
+    /**
+     * Access Token 블랙리스트 Redis 키 생성
+     * 예: blacklistKey("eyJ...") → "BL:eyJ..."
+     */
+    public static String blacklistKey(String accessToken) {
+        return BL_PREFIX + accessToken;
+    }
+}

--- a/src/main/java/com/clone/getchu/global/util/SecurityUtil.java
+++ b/src/main/java/com/clone/getchu/global/util/SecurityUtil.java
@@ -13,14 +13,19 @@ public class SecurityUtil {
     }
 
     public static Long getCurrentMemberId() {
+        return getAuthenticatedUserDetails().getMemberId();
+    }
+
+    public static String getCurrentMemberNickname() {
+        return getAuthenticatedUserDetails().getNickname();
+    }
+
+    private static CustomUserDetails getAuthenticatedUserDetails() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated() 
-            || authentication.getPrincipal().equals("anonymousUser")) {
-            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED); 
+        if (!(authentication != null && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
         }
-
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return userDetails.getMemberId();
+        return (CustomUserDetails) authentication.getPrincipal();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,19 +10,18 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 jwt:
   secret-key: ${JWT_SECRET_KEY}
-  # Refresh Token 미구현으로 인해 Access Token 만료시간을 24시간으로 설정
-  # 추후 Refresh Token 도입 시 15분(900000ms)으로 단축 예정
-  access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME:86400000}
+  access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME:900000}      # 15분
+  refresh-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME:604800000} # 7일


### PR DESCRIPTION
📝 작업 내용
- 인증/인가 시스템 구현
- 회원가입/로그인/로그아웃/토큰재발급 Auth API 구현
- Docker 환경변수 env 주입 방식을 통한 실행환경 구성

🔍 변경 사항
- JWT 0.11.x → 0.12.x 업그레이드
- Access Token 15분 + Refresh Token 7일 방식 도입
- Redis 블랙리스트 기반 로그아웃 처리 (AT 즉시 무효화)
- RedisKeyConstants 유틸클래스로 Redis 키 중앙 관리
- docker-compose.yml environment 블록 제거 → env_file과 environment 중복 주입 제거
- application.yml open-in-view: false 설정 및 dialect 제거

✅ 테스트
- [x] 로컬 Docker 실행 확인(./scripts/compose-up.sh)
- [ ] 예외 케이스 확인
- [x] 기존 기능 영향 확인

📸 스크린샷 / 결과 (./scripts/compose-up.sh명령어를 통한 실행 확인)
- <img width="1535" height="433" alt="image" src="https://github.com/user-attachments/assets/726bcb86-a679-4443-8ebf-2c7de52e0802" />
- 
<img width="386" height="138" alt="image" src="https://github.com/user-attachments/assets/070c6705-a896-4d25-a375-072a301010bb" />


💬 리뷰 포인트
- 잘못된 코드가 있는가?
- 하드코딩된 부분 잘 수정이 되었는가?

#️⃣ 연관 이슈
- close #4 