### PR TITLE
feat: 실시간 채팅 도메인 구현 (WebSocket/STOMP 적용)

### DIFF
--- a/src/main/java/com/clone/getchu/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/clone/getchu/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,48 @@
+package com.clone.getchu.domain.chat.controller;
+
+import com.clone.getchu.domain.chat.dto.request.ChatMessageRequest;
+import com.clone.getchu.domain.chat.service.ChatMessageService;
+import com.clone.getchu.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    /**
+     * STOMP 메시지 수신 엔드포인트
+     * 클라이언트: SEND destination=/app/chat.sendMessage
+     * 브로드캐스트: /topic/room.{chatRoomId}
+     *
+     * StompChannelInterceptor에서 accessor.setUser(authentication) 처리됨.
+     * principal은 UsernamePasswordAuthenticationToken이며
+     * getPrincipal()로 CustomUserDetails를 꺼낼 수 있음.
+     */
+    @MessageMapping("/chat.sendMessage")
+    public void sendMessage(@Valid @Payload ChatMessageRequest request, Principal principal) {
+        CustomUserDetails userDetails = extractUserDetails(principal);
+        chatMessageService.sendMessage(request, userDetails.getMemberId(), userDetails.getNickname());
+    }
+
+    /**
+     * STOMP Principal에서 CustomUserDetails 추출
+     * StompChannelInterceptor가 Authentication을 setUser()로 등록하므로
+     * Principal은 항상 Authentication의 구현체임.
+     */
+    private CustomUserDetails extractUserDetails(Principal principal) {
+        if (principal instanceof Authentication auth
+                && auth.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return userDetails;
+        }
+        throw new IllegalStateException("STOMP 인증 정보가 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,74 @@
+package com.clone.getchu.domain.chat.controller;
+
+import com.clone.getchu.domain.chat.dto.request.CreateChatRoomRequest;
+import com.clone.getchu.domain.chat.dto.response.ChatMessageResponse;
+import com.clone.getchu.domain.chat.dto.response.ChatRoomResponse;
+import com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse;
+import com.clone.getchu.domain.chat.service.ChatMessageService;
+import com.clone.getchu.domain.chat.service.ChatRoomService;
+import com.clone.getchu.global.common.ApiResponse;
+import com.clone.getchu.global.common.CursorPageResponse;
+import com.clone.getchu.global.util.SecurityUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat-rooms")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    /**
+     * POST /chat-rooms
+     * 채팅방 생성 (멱등)
+     * - 신규: 201 Created
+     * - 기존: 200 OK
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChatRoomResponse>> createOrGetChatRoom(
+            @Valid @RequestBody CreateChatRoomRequest request
+    ) {
+        Long buyerId = SecurityUtil.getCurrentMemberId();
+        ChatRoomResponse response = chatRoomService.createOrGetChatRoom(buyerId, request.getSellerId(), request);
+
+        if (response.isCreated()) {
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ApiResponse.success("채팅방이 생성되었습니다.", response));
+        }
+        return ResponseEntity.ok(ApiResponse.success("기존 채팅방을 반환합니다.", response));
+    }
+
+    /**
+     * GET /chat-rooms
+     * 내 채팅방 목록 조회 (구매자 또는 판매자로 참여한 채팅방)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ChatRoomSummaryResponse>>> getMyChatRooms() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        List<ChatRoomSummaryResponse> response = chatRoomService.getMyChatRooms(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * GET /chat-rooms/{chatRoomId}/messages?cursor={cursor}&size={size}
+     * 채팅 이력 조회 (Cursor 기반 페이지네이션)
+     */
+    @GetMapping("/{chatRoomId}/messages")
+    public ResponseEntity<ApiResponse<CursorPageResponse<ChatMessageResponse>>> getMessages(
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "30") int size
+    ) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        CursorPageResponse<ChatMessageResponse> response =
+                chatMessageService.getMessages(chatRoomId, memberId, cursor, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,17 @@
+package com.clone.getchu.domain.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageRequest {
+
+    @NotNull(message = "채팅방 ID는 필수입니다.")
+    private Long chatRoomId;
+
+    @NotBlank(message = "메시지 내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/clone/getchu/domain/chat/dto/request/CreateChatRoomRequest.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/request/CreateChatRoomRequest.java
@@ -1,0 +1,17 @@
+package com.clone.getchu.domain.chat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateChatRoomRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+    // TODO: Product 도메인 완성 후 productRepository로 sellerId를 자동 조회하고 해당 필드 제거
+    @NotNull(message = "판매자 ID는 필수입니다.")
+    private Long sellerId;
+}

--- a/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,28 @@
+package com.clone.getchu.domain.chat.dto.response;
+
+import com.clone.getchu.domain.chat.entity.ChatMessage;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatMessageResponse {
+
+    private final Long messageId;
+    private final Long chatRoomId;
+    private final Long senderId;
+    private final String senderNickname;
+    private final String content;
+    private final boolean isRead;
+    private final LocalDateTime createdAt;
+
+    public ChatMessageResponse(ChatMessage message) {
+        this.messageId = message.getId();
+        this.chatRoomId = message.getChatRoomId();
+        this.senderId = message.getSenderId();
+        this.senderNickname = message.getSenderNickname();
+        this.content = message.getContent();
+        this.isRead = message.isRead();
+        this.createdAt = message.getCreatedAt();
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatRoomResponse.java
@@ -1,0 +1,12 @@
+package com.clone.getchu.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomResponse {
+
+    private final Long chatRoomId;
+    private final boolean created; // true = 신규 생성, false = 기존 채팅방 반환
+}

--- a/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatRoomSummaryResponse.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatRoomSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.clone.getchu.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomSummaryResponse {
+
+    private final Long chatRoomId;
+    private final Long opponentId;
+    private final String opponentNickname;
+    private final Long productId;
+    private final String lastMessage;
+    private final long unreadCount;
+}

--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,47 @@
+package com.clone.getchu.domain.chat.entity;
+
+import com.clone.getchu.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "chat_message",
+        indexes = @Index(name = "idx_chat_message_room_id_desc", columnList = "chat_room_id, id DESC")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "chat_room_id", nullable = false)
+    private Long chatRoomId;
+
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    @Column(name = "sender_nickname", nullable = false)
+    private String senderNickname;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    // 정적 팩토리 메서드
+    public static ChatMessage create(Long chatRoomId, Long senderId, String senderNickname, String content) {
+        ChatMessage message = new ChatMessage();
+        message.chatRoomId = chatRoomId;
+        message.senderId = senderId;
+        message.senderNickname = senderNickname;
+        message.content = content;
+        message.isRead = false;
+        return message;
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,53 @@
+package com.clone.getchu.domain.chat.entity;
+
+import com.clone.getchu.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "chat_room",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_chat_room_buyer_product",
+                columnNames = {"buyer_id", "product_id"}
+        ),
+        indexes = @Index(name = "idx_chat_room_seller_id", columnList = "seller_id")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Product 도메인이 완성될 때까지 FK만 보유 (연관관계 제외)
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "buyer_id", nullable = false)
+    private Long buyerId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "last_message_at")
+    private LocalDateTime lastMessageAt;
+
+    // 정적 팩토리 메서드
+    public static ChatRoom create(Long productId, Long buyerId, Long sellerId) {
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.productId = productId;
+        chatRoom.buyerId = buyerId;
+        chatRoom.sellerId = sellerId;
+        return chatRoom;
+    }
+
+    public void updateLastMessageAt(LocalDateTime lastMessageAt) {
+        this.lastMessageAt = lastMessageAt;
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,19 @@
+package com.clone.getchu.domain.chat.repository;
+
+import com.clone.getchu.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    // Cursor 기반 페이지네이션: cursor(messageId) 이전 메시지 조회
+    List<ChatMessage> findByChatRoomIdAndIdLessThanOrderByIdDesc(Long chatRoomId, Long cursor, Pageable pageable);
+
+    // 첫 페이지 조회 (cursor 없을 때)
+    List<ChatMessage> findByChatRoomIdOrderByIdDesc(Long chatRoomId, Pageable pageable);
+
+    // 읽지 않은 메시지 수 (상대방이 보낸 메시지 중 isRead=false)
+    long countByChatRoomIdAndSenderIdNotAndIsReadFalse(Long chatRoomId, Long myId);
+}

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,16 @@
+package com.clone.getchu.domain.chat.repository;
+
+import com.clone.getchu.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 중복 채팅방 조회 (멱등 생성용)
+    Optional<ChatRoom> findByBuyerIdAndProductId(Long buyerId, Long productId);
+
+    // 내 채팅방 목록 조회 (구매자 또는 판매자로 참여한 채팅방, 최신 메시지 순)
+    List<ChatRoom> findByBuyerIdOrSellerIdOrderByLastMessageAtDesc(Long buyerId, Long sellerId);
+}

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,93 @@
+package com.clone.getchu.domain.chat.service;
+
+import com.clone.getchu.domain.chat.dto.request.ChatMessageRequest;
+import com.clone.getchu.domain.chat.dto.response.ChatMessageResponse;
+import com.clone.getchu.domain.chat.entity.ChatMessage;
+import com.clone.getchu.domain.chat.entity.ChatRoom;
+import com.clone.getchu.domain.chat.repository.ChatMessageRepository;
+import com.clone.getchu.global.common.CursorPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private static final int DEFAULT_PAGE_SIZE = 30;
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomService chatRoomService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 메시지 전송 (STOMP WebSocket)
+     * 1. 채팅방 존재 + 참여자 검증
+     * 2. DB 저장
+     * 3. lastMessageAt 업데이트
+     * 4. /topic/room.{chatRoomId} 브로드캐스트
+     */
+    @Transactional
+    public void sendMessage(ChatMessageRequest request, Long senderId, String senderNickname) {
+        ChatRoom chatRoom = chatRoomService.validateAndGetChatRoom(request.getChatRoomId(), senderId);
+
+        // 메시지 저장
+        ChatMessage message = ChatMessage.create(
+                request.getChatRoomId(),
+                senderId,
+                senderNickname,
+                request.getContent()
+        );
+        chatMessageRepository.save(message);
+
+        // 채팅방 lastMessageAt 갱신
+        chatRoom.updateLastMessageAt(LocalDateTime.now());
+
+        // STOMP 브로드캐스트 → /topic/room.{chatRoomId}
+        ChatMessageResponse response = new ChatMessageResponse(message);
+        messagingTemplate.convertAndSend("/topic/room." + request.getChatRoomId(), response);
+    }
+
+    /**
+     * 채팅 이력 조회 (Cursor 기반 페이지네이션)
+     * - cursor 없음: 최신 메시지부터 size개 조회
+     * - cursor 있음: cursor(messageId) 이전 메시지부터 size개 조회
+     * - size+1 조회 후 hasNext 판단, nextCursor = 마지막 messageId
+     */
+    @Transactional(readOnly = true)
+    public CursorPageResponse<ChatMessageResponse> getMessages(Long chatRoomId, Long memberId, Long cursor, int size) {
+        // 채팅방 존재 + 참여자 검증
+        chatRoomService.validateAndGetChatRoom(chatRoomId, memberId);
+
+        int fetchSize = size + 1; // hasNext 판단용 +1
+        PageRequest pageable = PageRequest.of(0, fetchSize);
+
+        List<ChatMessage> messages;
+        if (cursor == null) {
+            messages = chatMessageRepository.findByChatRoomIdOrderByIdDesc(chatRoomId, pageable);
+        } else {
+            messages = chatMessageRepository.findByChatRoomIdAndIdLessThanOrderByIdDesc(chatRoomId, cursor, pageable);
+        }
+
+        boolean hasNext = messages.size() == fetchSize;
+        if (hasNext) {
+            messages = messages.subList(0, size); // 실제 반환할 size개만
+        }
+
+        String nextCursor = (hasNext && !messages.isEmpty())
+                ? String.valueOf(messages.get(messages.size() - 1).getId())
+                : null;
+
+        List<ChatMessageResponse> content = messages.stream()
+                .map(ChatMessageResponse::new)
+                .collect(Collectors.toList());
+
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,116 @@
+package com.clone.getchu.domain.chat.service;
+
+import com.clone.getchu.domain.chat.dto.request.CreateChatRoomRequest;
+import com.clone.getchu.domain.chat.dto.response.ChatRoomResponse;
+import com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse;
+import com.clone.getchu.domain.chat.entity.ChatRoom;
+import com.clone.getchu.domain.chat.repository.ChatMessageRepository;
+import com.clone.getchu.domain.chat.repository.ChatRoomRepository;
+import com.clone.getchu.domain.member.entity.Member;
+import com.clone.getchu.domain.member.repository.MemberRepository;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.InvalidRequestException;
+import com.clone.getchu.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 채팅방 생성 (멱등)
+     * - 동일 (buyerId, productId) 채팅방이 이미 존재하면 기존 채팅방 반환 (created=false)
+     * - 없으면 새로 생성 (created=true)
+     *
+     * NOTE: Product 도메인이 없으므로 현재 sellerId를 요청자가 직접 전달하지 않음.
+     *       Product 도메인 완성 시 productRepository로 sellerId 조회 후 자동 주입.
+     *       임시로 productId를 sellerId로 사용하는 구조 대신, sellerId를 request에 포함.
+     */
+    @Transactional
+    public ChatRoomResponse createOrGetChatRoom(Long buyerId, Long sellerId, CreateChatRoomRequest request) {
+        // 본인 상품 채팅 시도 방지
+        if (buyerId.equals(sellerId)) {
+            throw new InvalidRequestException(ErrorCode.SELF_CHAT);
+        }
+
+        // 이미 존재하는 채팅방 확인 (멱등)
+        Optional<ChatRoom> existingRoom = chatRoomRepository.findByBuyerIdAndProductId(buyerId, request.getProductId());
+        if (existingRoom.isPresent()) {
+            return new ChatRoomResponse(existingRoom.get().getId(), false);
+        }
+
+        // 새 채팅방 생성
+        ChatRoom chatRoom = ChatRoom.create(request.getProductId(), buyerId, sellerId);
+        chatRoomRepository.save(chatRoom);
+        return new ChatRoomResponse(chatRoom.getId(), true);
+    }
+
+    /**
+     * 내 채팅방 목록 조회
+     * - 구매자 또는 판매자로 참여한 채팅방 반환 (최신 메시지 순)
+     */
+    @Transactional(readOnly = true)
+    public List<ChatRoomSummaryResponse> getMyChatRooms(Long memberId) {
+        List<ChatRoom> chatRooms = chatRoomRepository
+                .findByBuyerIdOrSellerIdOrderByLastMessageAtDesc(memberId, memberId);
+
+        return chatRooms.stream()
+                .map(room -> {
+                    boolean isBuyer = room.getBuyerId().equals(memberId);
+                    Long opponentId = isBuyer ? room.getSellerId() : room.getBuyerId();
+
+                    // 상대방 닉네임 조회
+                    String opponentNickname = memberRepository.findById(opponentId)
+                            .map(Member::getNickname)
+                            .orElse("탈퇴한 회원");
+
+                    // 마지막 메시지 조회
+                    String lastMessage = chatMessageRepository
+                            .findByChatRoomIdOrderByIdDesc(room.getId(),
+                                    org.springframework.data.domain.PageRequest.of(0, 1))
+                            .stream()
+                            .findFirst()
+                            .map(msg -> msg.getContent())
+                            .orElse("");
+
+                    // 읽지 않은 메시지 수
+                    long unreadCount = chatMessageRepository
+                            .countByChatRoomIdAndSenderIdNotAndIsReadFalse(room.getId(), memberId);
+
+                    return new ChatRoomSummaryResponse(
+                            room.getId(),
+                            opponentId,
+                            opponentNickname,
+                            room.getProductId(),
+                            lastMessage,
+                            unreadCount
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 채팅방 존재 확인 및 참여자 검증 (다른 서비스에서 공통 사용)
+     */
+    @Transactional(readOnly = true)
+    public ChatRoom validateAndGetChatRoom(Long chatRoomId, Long memberId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoom.getBuyerId().equals(memberId) && !chatRoom.getSellerId().equals(memberId)) {
+            throw new com.clone.getchu.global.exception.ForbiddenException(ErrorCode.CHAT_FORBIDDEN);
+        }
+
+        return chatRoom;
+    }
+}


### PR DESCRIPTION
📝 작업 내용

- 실시간 채팅 기능(도메인) A부터 Z까지 신규 구현 완료
- WebSocket 및 STOMP 프로토콜을 이용한 실시간 채팅 메시지 브로드캐스트 기능 추가
- 이전 대화 내역 조회를 위한 커서 기반 페이지네이션(Cursor Pagination) 적용

🔍 변경 사항

- domain/chat 패키지를 완전히 새로 구성하여 11개의 파일(Entity, Repository, DTO, Service, Controller) 신규 창설
- 중복 채팅방 생성을 방지하기 위한 DB 인덱스(UNIQUE 키) 및 멱등 로직 적용
- SecurityConfig에 설정된 인증 체계를 활용해 STOMP 연결 시 JwtAuthFilter 와 동일한 JWT 검증 로직 통과 유도
- 프로젝트 최상단에 누락되었던 .gitignore 파일을 추가하여 .env, chat-test.html, build/ 등이 커밋되지 않도록 덮어씌움

✅ 테스트

- 로컬 실행 확인 (Docker를 이용한 MySQL 8.x, Redis, Spring Boot 실행 완료)
- API 테스트 완료 (Postman을 활용한 HTTP 채팅방 생성/목록/이력 조회 및 WebSocket STOMP 프로토콜 송수신 확인)
- 예외 케이스 확인 (본인의 상품에 본인이 채팅을 거는 케이스 HTTP 400 에러 처리 완료)
- 기존 기능 영향 확인 (인증 과정 정상 통과, 기타 도메인 터치 없음)

💬 리뷰 포인트

- 아직 Product 도메인이 프로젝트에 Merge 되지 않아서, 채팅방 생성 요청(CreateChatRoomRequest)에서 임시로 sellerId를 직접 RequestBody로 받고 있습니다. 나중에 Product 도메인이 완성되면 이 파라미터를 지우고 DB에서 productId로 판매자를 직접 찾게끔 수정할 예정입니다! 이 부분 감안해서 리뷰 부탁드려요!