### PR TITLE
fix: N+1 문제 해결

### DIFF
--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
@@ -20,7 +20,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT new com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse(" +
            "cr.id, CASE WHEN cr.buyerId = :memberId THEN cr.sellerId ELSE cr.buyerId END, " +
            "COALESCE(m.nickname, '탈퇴한 회원'), cr.productId, " +
-           "(SELECT cm.content FROM ChatMessage cm WHERE cm.chatRoomId = cr.id ORDER BY cm.id DESC LIMIT 1), " +
+           "(SELECT cm.content FROM ChatMessage cm WHERE cm.id = (SELECT MAX(cm2.id) FROM ChatMessage cm2 WHERE cm2.chatRoomId = cr.id)), " +
            "(SELECT COUNT(cm2) FROM ChatMessage cm2 WHERE cm2.chatRoomId = cr.id AND cm2.senderId <> :memberId AND cm2.isRead = false)" +
            ") " +
            "FROM ChatRoom cr " +

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,8 @@ package com.clone.getchu.domain.chat.repository;
 
 import com.clone.getchu.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,17 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     // 내 채팅방 목록 조회 (구매자 또는 판매자로 참여한 채팅방, 최신 메시지 순)
     List<ChatRoom> findByBuyerIdOrSellerIdOrderByLastMessageAtDesc(Long buyerId, Long sellerId);
+
+    // 채팅방 목록 최적화 조회 (N+1 해결)
+    @Query("SELECT new com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse(" +
+           "cr.id, CASE WHEN cr.buyerId = :memberId THEN cr.sellerId ELSE cr.buyerId END, " +
+           "COALESCE(m.nickname, '탈퇴한 회원'), cr.productId, " +
+           "(SELECT cm.content FROM ChatMessage cm WHERE cm.chatRoomId = cr.id ORDER BY cm.id DESC LIMIT 1), " +
+           "(SELECT COUNT(cm2) FROM ChatMessage cm2 WHERE cm2.chatRoomId = cr.id AND cm2.senderId <> :memberId AND cm2.isRead = false)" +
+           ") " +
+           "FROM ChatRoom cr " +
+           "LEFT JOIN Member m ON (CASE WHEN cr.buyerId = :memberId THEN cr.sellerId ELSE cr.buyerId END) = m.id " +
+           "WHERE cr.buyerId = :memberId OR cr.sellerId = :memberId " +
+           "ORDER BY cr.lastMessageAt DESC")
+    List<com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse> findMyChatRoomSummaries(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -65,42 +65,7 @@ public class ChatRoomService {
      */
     @Transactional(readOnly = true)
     public List<ChatRoomSummaryResponse> getMyChatRooms(Long memberId) {
-        List<ChatRoom> chatRooms = chatRoomRepository
-                .findByBuyerIdOrSellerIdOrderByLastMessageAtDesc(memberId, memberId);
-
-        return chatRooms.stream()
-                .map(room -> {
-                    boolean isBuyer = room.getBuyerId().equals(memberId);
-                    Long opponentId = isBuyer ? room.getSellerId() : room.getBuyerId();
-
-                    // 상대방 닉네임 조회
-                    String opponentNickname = memberRepository.findById(opponentId)
-                            .map(Member::getNickname)
-                            .orElse("탈퇴한 회원");
-
-                    // 마지막 메시지 조회
-                    String lastMessage = chatMessageRepository
-                            .findByChatRoomIdOrderByIdDesc(room.getId(),
-                                    org.springframework.data.domain.PageRequest.of(0, 1))
-                            .stream()
-                            .findFirst()
-                            .map(msg -> msg.getContent())
-                            .orElse("");
-
-                    // 읽지 않은 메시지 수
-                    long unreadCount = chatMessageRepository
-                            .countByChatRoomIdAndSenderIdNotAndIsReadFalse(room.getId(), memberId);
-
-                    return new ChatRoomSummaryResponse(
-                            room.getId(),
-                            opponentId,
-                            opponentNickname,
-                            room.getProductId(),
-                            lastMessage,
-                            unreadCount
-                    );
-                })
-                .collect(Collectors.toList());
+        return chatRoomRepository.findMyChatRoomSummaries(memberId);
     }
 
     /**


### PR DESCRIPTION
📝 작업 내용
- 채팅방 목록 조회 시 발생하는 심각한 N+1 쿼리 병목 현상 해결
- 서비스 로직 내 반복문(for-loop) 다건 조회를 단일 레포지토리 쿼리로 단축
- 상대방이 회원 탈퇴 시 내 채팅방 목록이 증발하는 버그 선제적 해결

🔍 변경 사항
- 수정 부분: ChatRoomService.getMyChatRooms(), ChatRoomRepository
- 달라진 점:
- 엔티티 여러 번 찌르던 로직 지우고, JPA DTO Projection(@Query) 도입하여 단 한번의 쿼리로 모든 데이터 가져오게 변경
- Member 테이블 조인 시 INNER JOIN을 LEFT JOIN으로 바꾸고 COALESCE 함수를 적용하여 상대방이 탈퇴(deleted=true)해도 채팅 내역이 안전하게 유지됨

✅ 테스트
- 로컬 빌드 및 실행 확인
- API 동작 및 속도 테스트 완료
- 예외 케이스 확인 (상대방 계정 탈퇴/삭제 시 방어 로직 검증)
- 기존 기능 영향 확인

💬 리뷰 포인트
- N+1 해결을 위해 조인 및 스칼라 서브쿼리로 Projection 한 @Query 구문 구조 검토 부탁드립니다.

#️⃣ 연관 이슈
close # (이슈 번호 작성)