### PR TITLE
feat: 채팅방 나가기 기능 구현

### DIFF
--- a/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
@@ -71,4 +71,15 @@ public class ChatRoomController {
                 chatMessageService.getMessages(chatRoomId, memberId, cursor, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    /**
+     * DELETE /chat-rooms/{chatRoomId}/leave
+     * 채팅방 나가기 (Soft Delete)
+     */
+    @DeleteMapping("/{chatRoomId}/leave")
+    public ResponseEntity<ApiResponse<Void>> leaveChatRoom(@PathVariable Long chatRoomId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        chatRoomService.leaveChatRoom(memberId, chatRoomId);
+        return ResponseEntity.ok(ApiResponse.success("채팅방을 성공적으로 나갔습니다.", null));
+    }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
@@ -68,8 +68,11 @@ public class ChatRoom extends BaseEntity {
         }
     }
 
-    public void reenterRoom() {
-        this.deletedByBuyer = false;
-        this.deletedBySeller = false;
+    public void reenterRoom(Long senderId) {
+        if (this.buyerId.equals(senderId)) {
+            this.deletedByBuyer = false;
+        } else if (this.sellerId.equals(senderId)) {
+            this.deletedBySeller = false;
+        }
     }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
@@ -39,6 +39,12 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "last_message_at")
     private LocalDateTime lastMessageAt;
 
+    @Column(name = "deleted_by_buyer", nullable = false)
+    private boolean deletedByBuyer = false;
+
+    @Column(name = "deleted_by_seller", nullable = false)
+    private boolean deletedBySeller = false;
+
     @Builder
     private ChatRoom(Long productId, Long buyerId, Long sellerId) {
         this.productId = productId;
@@ -48,5 +54,18 @@ public class ChatRoom extends BaseEntity {
 
     public void updateLastMessageAt(LocalDateTime lastMessageAt) {
         this.lastMessageAt = lastMessageAt;
+    }
+
+    public void leaveRoom(Long memberId) {
+        if (this.buyerId.equals(memberId)) {
+            this.deletedByBuyer = true;
+        } else if (this.sellerId.equals(memberId)) {
+            this.deletedBySeller = true;
+        }
+    }
+
+    public void reenterRoom() {
+        this.deletedByBuyer = false;
+        this.deletedBySeller = false;
     }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
@@ -1,6 +1,8 @@
 package com.clone.getchu.domain.chat.entity;
 
 import com.clone.getchu.global.common.BaseEntity;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.ForbiddenException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -61,6 +63,8 @@ public class ChatRoom extends BaseEntity {
             this.deletedByBuyer = true;
         } else if (this.sellerId.equals(memberId)) {
             this.deletedBySeller = true;
+        } else {
+            throw new ForbiddenException(ErrorCode.CHAT_FORBIDDEN);
         }
     }
 

--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
@@ -75,4 +75,13 @@ public class ChatRoom extends BaseEntity {
             this.deletedBySeller = false;
         }
     }
+
+    public boolean isLeftBy(Long memberId) {
+        if (this.buyerId.equals(memberId)) {
+            return this.deletedByBuyer;
+        } else if (this.sellerId.equals(memberId)) {
+            return this.deletedBySeller;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
@@ -25,7 +25,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
            ") " +
            "FROM ChatRoom cr " +
            "LEFT JOIN Member m ON (CASE WHEN cr.buyerId = :memberId THEN cr.sellerId ELSE cr.buyerId END) = m.id " +
-           "WHERE cr.buyerId = :memberId OR cr.sellerId = :memberId " +
+           "WHERE (cr.buyerId = :memberId AND cr.deletedByBuyer = false) OR (cr.sellerId = :memberId AND cr.deletedBySeller = false) " +
            "ORDER BY cr.lastMessageAt DESC")
     List<com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse> findMyChatRoomSummaries(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -46,9 +46,9 @@ public class ChatMessageService {
                 .build();
         chatMessageRepository.save(message);
 
-        // 채팅방 lastMessageAt 및 퇴장 상태 갱신 (메시지 수신 시 방 복구)
+        // lastMessageAt 갱신 & 메시지를 보낸 사람의 퇴장 상태만 복구
         chatRoom.updateLastMessageAt(LocalDateTime.now());
-        chatRoom.reenterRoom();
+        chatRoom.reenterRoom(senderId);
 
         // STOMP 브로드캐스트 → /topic/room.{chatRoomId}
         ChatMessageResponse response = ChatMessageResponse.from(message);

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -63,8 +63,8 @@ public class ChatMessageService {
      */
     @Transactional(readOnly = true)
     public CursorPageResponse<ChatMessageResponse> getMessages(Long chatRoomId, Long memberId, Long cursor, int size) {
-        // 채팅방 존재 + 참여자 검증
-        chatRoomService.validateAndGetChatRoom(chatRoomId, memberId);
+        // 채팅방 존재 + 참여자 검증 + 나가지 않은 상태인지 검증
+        chatRoomService.validateActiveChatRoom(chatRoomId, memberId);
 
         int fetchSize = size + 1; // hasNext 판단용 +1
         PageRequest pageable = PageRequest.of(0, fetchSize);

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -46,8 +46,9 @@ public class ChatMessageService {
                 .build();
         chatMessageRepository.save(message);
 
-        // 채팅방 lastMessageAt 갱신
+        // 채팅방 lastMessageAt 및 퇴장 상태 갱신 (메시지 수신 시 방 복구)
         chatRoom.updateLastMessageAt(LocalDateTime.now());
+        chatRoom.reenterRoom();
 
         // STOMP 브로드캐스트 → /topic/room.{chatRoomId}
         ChatMessageResponse response = ChatMessageResponse.from(message);

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -44,8 +44,9 @@ public class ChatRoomService {
         Optional<ChatRoom> existingRoom = chatRoomRepository.findByBuyerIdAndProductId(buyerId, request.productId());
         if (existingRoom.isPresent()) {
             ChatRoom room = existingRoom.get();
-            // 구매자가 이전에 방을 나갔을 경우 재입장 처리
+            // 구매자가 이전에 방을 나갔을 경우 재입장 처리 후 즉시 DB 반영
             room.reenterRoom(buyerId);
+            chatRoomRepository.saveAndFlush(room);
             return new ChatRoomResponse(room.getId(), false);
         }
 
@@ -87,11 +88,13 @@ public class ChatRoomService {
      * 채팅방 나가기 (Soft Delete)
      * - DB에서 삭제하지 않고, 나갔다는 플래그만 변경
      * - 채팅방 존재 여부만 확인하고, 참여자 권한 검증은 엔티티의 leaveRoom()에 위임
+     * - saveAndFlush()로 영속성 컨텍스트를 즉시 DB에 반영하여 JPQL 쿼리와의 비동기화 방지
      */
     @Transactional
     public void leaveChatRoom(Long memberId, Long chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         chatRoom.leaveRoom(memberId);
+        chatRoomRepository.saveAndFlush(chatRoom); // Soft Delete 플래그 즉시 DB 반영
     }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -85,6 +85,21 @@ public class ChatRoomService {
     }
 
     /**
+     * 채팅방 존재 확인 및 활성 참여자(나가지 않은 상태) 검증
+     * - 메시지 이력 조회, 무한 스크롤, STOMP 구독 등 '읽기' 권한 검증에 사용
+     */
+    @Transactional(readOnly = true)
+    public ChatRoom validateActiveChatRoom(Long chatRoomId, Long memberId) {
+        ChatRoom chatRoom = validateAndGetChatRoom(chatRoomId, memberId);
+
+        if (chatRoom.isLeftBy(memberId)) {
+            throw new ForbiddenException(ErrorCode.CHAT_ALREADY_LEFT);
+        }
+
+        return chatRoom;
+    }
+
+    /**
      * 채팅방 나가기 (Soft Delete)
      * - DB에서 삭제하지 않고, 나갔다는 플래그만 변경
      * - 채팅방 존재 여부만 확인하고, 참여자 권한 검증은 엔티티의 leaveRoom()에 위임

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -6,9 +6,8 @@ import com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse;
 import com.clone.getchu.domain.chat.entity.ChatRoom;
 import com.clone.getchu.domain.chat.repository.ChatMessageRepository;
 import com.clone.getchu.domain.chat.repository.ChatRoomRepository;
-import com.clone.getchu.domain.member.entity.Member;
-import com.clone.getchu.domain.member.repository.MemberRepository;
 import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.ForbiddenException;
 import com.clone.getchu.global.exception.InvalidRequestException;
 import com.clone.getchu.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +23,6 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final MemberRepository memberRepository;
 
     /**
      * 채팅방 생성 (멱등)
@@ -77,7 +74,7 @@ public class ChatRoomService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         if (!chatRoom.getBuyerId().equals(memberId) && !chatRoom.getSellerId().equals(memberId)) {
-            throw new com.clone.getchu.global.exception.ForbiddenException(ErrorCode.CHAT_FORBIDDEN);
+            throw new ForbiddenException(ErrorCode.CHAT_FORBIDDEN);
         }
 
         return chatRoom;

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -82,4 +82,14 @@ public class ChatRoomService {
 
         return chatRoom;
     }
+
+    /**
+     * 채팅방 나가기 (Soft Delete)
+     * - DB에서 삭제하지 않고, 나갔다는 플래그만 변경
+     */
+    @Transactional
+    public void leaveChatRoom(Long memberId, Long chatRoomId) {
+        ChatRoom chatRoom = validateAndGetChatRoom(chatRoomId, memberId);
+        chatRoom.leaveRoom(memberId);
+    }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -43,7 +43,10 @@ public class ChatRoomService {
         // 이미 존재하는 채팅방 확인 (멱등)
         Optional<ChatRoom> existingRoom = chatRoomRepository.findByBuyerIdAndProductId(buyerId, request.productId());
         if (existingRoom.isPresent()) {
-            return new ChatRoomResponse(existingRoom.get().getId(), false);
+            ChatRoom room = existingRoom.get();
+            // 구매자가 이전에 방을 나갔을 경우 재입장 처리
+            room.reenterRoom(buyerId);
+            return new ChatRoomResponse(room.getId(), false);
         }
 
         // 새 채팅방 생성
@@ -83,10 +86,12 @@ public class ChatRoomService {
     /**
      * 채팅방 나가기 (Soft Delete)
      * - DB에서 삭제하지 않고, 나갔다는 플래그만 변경
+     * - 채팅방 존재 여부만 확인하고, 참여자 권한 검증은 엔티티의 leaveRoom()에 위임
      */
     @Transactional
     public void leaveChatRoom(Long memberId, Long chatRoomId) {
-        ChatRoom chatRoom = validateAndGetChatRoom(chatRoomId, memberId);
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         chatRoom.leaveRoom(memberId);
     }
 }

--- a/src/main/java/com/clone/getchu/global/exception/ErrorCode.java
+++ b/src/main/java/com/clone/getchu/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "존재하지 않는 채팅방입니다."),
     SELF_CHAT(HttpStatus.BAD_REQUEST, "C002", "본인의 판매글에는 채팅을 시작할 수 없습니다."),
     CHAT_FORBIDDEN(HttpStatus.FORBIDDEN, "C003", "해당 채팅방에 대한 권한이 없습니다."),
+    CHAT_ALREADY_LEFT(HttpStatus.FORBIDDEN, "C004", "이미 나간 채팅방입니다."),
 
     // ===== REVIEW (R) =====
     REVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "R001", "거래 완료(SOLD) 상태에서만 리뷰를 작성할 수 있습니다."),

--- a/src/main/java/com/clone/getchu/global/security/StompChannelInterceptor.java
+++ b/src/main/java/com/clone/getchu/global/security/StompChannelInterceptor.java
@@ -1,5 +1,6 @@
 package com.clone.getchu.global.security;
 
+import com.clone.getchu.domain.chat.service.ChatRoomService;
 import com.clone.getchu.global.exception.ErrorCode;
 import com.clone.getchu.global.exception.UnauthorizedException;
 import com.clone.getchu.global.util.RedisKeyConstants;
@@ -36,6 +37,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate stringRedisTemplate;
+    private final ChatRoomService chatRoomService;
 
     // 메시지가 채널로 전송되기 직전에 호출됨
     @Override
@@ -65,6 +67,24 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             // STOMP 세션에 인증 정보 등록 - 이후 convertAndSendToUser() 시 이 user 정보를 사용해 라우팅
             accessor.setUser(auth);
             log.debug("WebSocket CONNECT 인증 성공 - user: {}", auth.getName());
+        }
+
+        // 구독(SUBSCRIBE) 시 채팅방 참여자 검증 (나간 방 접근 차단)
+        if (accessor != null && StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            String destination = accessor.getDestination();
+            if (destination != null && destination.startsWith("/topic/room.")) {
+                try {
+                    Long chatRoomId = Long.valueOf(destination.substring("/topic/room.".length()));
+                    Authentication auth = (Authentication) accessor.getUser();
+                    if (auth != null && auth.getPrincipal() instanceof CustomUserDetails userDetails) {
+                        // 읽기(구독) 권한은 나가지 않은 참여자만 가능
+                        chatRoomService.validateActiveChatRoom(chatRoomId, userDetails.getMemberId());
+                        log.debug("WebSocket SUBSCRIBE 검증 성공 - room:{}, user:{}", chatRoomId, userDetails.getMemberId());
+                    }
+                } catch (NumberFormatException e) {
+                    log.warn("STOMP 구독 목적지 형식 오류: {}", destination);
+                }
+            }
         }
 
         return message;


### PR DESCRIPTION
📝 작업 내용
- 채팅방 나가기(Soft Delete) REST API 엔드포인트 구현
- 현재 사용자가 나간 채팅방은 '내 채팅방 목록' 조회 화면에서 제외되도록 쿼리 수정
- 채팅방을 나간 상태에서 상대방으로부터 새로운 메시지가 도착하면 채팅방 목록에 다시 노출(재활성화)되도록 로직 추가

🔍 변경 사항
- **`ChatRoom` (Entity)**: `deletedByBuyer`, `deletedBySeller` 상태 필드 추가 및 `leaveRoom()`, `reenterRoom()` 플래그 관리 메서드 구현 
- **`ChatRoomController` / `ChatRoomService`**: `DELETE /api/chat-rooms/{chatRoomId}/leave` 요청을 처리하는 컨트롤러 및 서비스 로직(참여자 검증 후 상태 변경) 추가
- **`ChatRoomRepository`**: `findMyChatRoomSummaries` JPQL 쿼리 내에 나가지 않은 방(`deletedByBuyer = false` 또는 `deletedBySeller = false`)만 조회되도록 조건절 추가
- **`ChatMessageService`**: `sendMessage()` 로직 실행 시 `chatRoom.reenterRoom()`을 동작시켜, 새 메시지 수신 시 나갔던 채팅방이 부활하도록 변경

✅ 테스트
- [x] 로컬 실행 확인
- [x] API 테스트 완료 (Postman을 활용한 본인 방 나가기, 타인 방 접근 예외 등)
- [x] 예외 케이스 확인 (참여자가 아닌 회원이 나가기를 시도할 경우 `ForbiddenException` 테스트)
- [x] 기존 기능 영향 확인 (기존 채팅 기능 및 메시지 전송과 충돌 없음)


💬 리뷰 포인트
- 채팅 기록을 DB에서 물리적으로 지우지 않고(Hard Delete 방지) 상태값(`deletedBy...`)만 변경하는 **Soft Delete** 방식으로 구현했습니다.
- 타 메신저(카카오톡, 당근마켓 등)와 동일하게 **방을 나간 상대방이 메시지를 보내면 채팅방이 다시 활성화**되도록 `reenterRoom()`을 적용했는데, 이 흐름의 방향성을 중점적으로 검토해 주시면 좋겠습니다!
- `ChatRoomRepository`의 목록 조회 JPQL에 조건이 추가되었는데, 성능상 이슈나 개선점이 있을지 리뷰 부탁드립니다.

#️⃣ 연관 이슈
- close #33