### PR TITLE
fix: 백엔드와 연동하면서 프론트엔드에서 원하는 요청, 응답 필드 수정 및 추가

### DIFF
--- a/src/main/java/com/clone/getchu/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/SignupRequest.java
@@ -32,7 +32,7 @@ public record SignupRequest(
 
         // 프로필 이미지 URL (선택, null 허용)
         // 미입력 시 프론트에서 기본 이미지 표시
-        @Pattern(regexp = "^(https?://.*)?$", message = "올바른 URL 형식이어야 합니다.")
+//        @Pattern(regexp = "^(https?://.*)?$", message = "올바른 URL 형식이어야 합니다.")
         String profileImageUrl
 
 ) {}

--- a/src/main/java/com/clone/getchu/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/clone/getchu/domain/auth/dto/SignupRequest.java
@@ -30,9 +30,8 @@ public record SignupRequest(
         @Size(min = 2, max = 20, message = "닉네임은 2~20자여야 합니다.")
         String nickname,
 
-        // 프로필 이미지 URL (선택, null 허용)
-        // 미입력 시 프론트에서 기본 이미지 표시
-//        @Pattern(regexp = "^(https?://.*)?$", message = "올바른 URL 형식이어야 합니다.")
+        // 프로필 이미지 URL 또는 Base64 데이터 URI (선택, null 허용)
+        @Pattern(regexp = "^(https?://.*|data:image/.*)?$", message = "올바른 이미지 형식이어야 합니다.")
         String profileImageUrl
 
 ) {}

--- a/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatRoomSummaryResponse.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatRoomSummaryResponse.java
@@ -5,6 +5,7 @@ public record ChatRoomSummaryResponse(
         Long opponentId,
         String opponentNickname,
         Long productId,
+        String opponentProfileImageUrl,
         String lastMessage,
         long unreadCount
 ) {

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatRoomRepository.java
@@ -19,7 +19,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     // 채팅방 목록 최적화 조회 (N+1 해결)
     @Query("SELECT new com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse(" +
            "cr.id, CASE WHEN cr.buyerId = :memberId THEN cr.sellerId ELSE cr.buyerId END, " +
-           "COALESCE(m.nickname, '탈퇴한 회원'), cr.productId, " +
+           "COALESCE(m.nickname, '탈퇴한 회원'), cr.productId, m.profileImageUrl, " +
            "(SELECT cm.content FROM ChatMessage cm WHERE cm.id = (SELECT MAX(cm2.id) FROM ChatMessage cm2 WHERE cm2.chatRoomId = cr.id)), " +
            "(SELECT COUNT(cm2) FROM ChatMessage cm2 WHERE cm2.chatRoomId = cr.id AND cm2.senderId <> :memberId AND cm2.isRead = false)" +
            ") " +

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -46,6 +46,7 @@ public class ChatRoomService {
             ChatRoom room = existingRoom.get();
             // 구매자가 이전에 방을 나갔을 경우 재입장 처리 후 즉시 DB 반영
             room.reenterRoom(buyerId);
+            room.reenterRoom(sellerId);
             chatRoomRepository.saveAndFlush(room);
             return new ChatRoomResponse(room.getId(), false);
         }

--- a/src/main/java/com/clone/getchu/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/clone/getchu/domain/member/dto/request/MemberUpdateRequest.java
@@ -7,8 +7,8 @@ public record MemberUpdateRequest(
         @Size(min = 2, max = 20, message = "닉네임은 2~20자여야 합니다.")
         String nickname,
         // 빈 문자열("")을 허용: 프론트가 ""를 보내면 프로필 이미지 삭제 의도로 해석
-        // null은 "변경 의사 없음"으로 해석 (패턴: null = 미전송, "" = 명시적 삭제, URL = 업데이트)
-//        @Pattern(regexp = "^(https?://.*)?$", message = "올바른 URL 형식이어야 합니다.")
+        // null은 "변경 의사 없음"으로 해석 (패턴: null = 미전송, "" = 명시적 삭제, URL/Base64 = 업데이트)
+        @Pattern(regexp = "^(https?://.*|data:image/.*)?$", message = "올바른 이미지 형식이어야 합니다.")
         String profileImageUrl
 ) {
     public MemberUpdateRequest {

--- a/src/main/java/com/clone/getchu/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/clone/getchu/domain/member/dto/request/MemberUpdateRequest.java
@@ -8,7 +8,7 @@ public record MemberUpdateRequest(
         String nickname,
         // 빈 문자열("")을 허용: 프론트가 ""를 보내면 프로필 이미지 삭제 의도로 해석
         // null은 "변경 의사 없음"으로 해석 (패턴: null = 미전송, "" = 명시적 삭제, URL = 업데이트)
-        @Pattern(regexp = "^(https?://.*)?$", message = "올바른 URL 형식이어야 합니다.")
+//        @Pattern(regexp = "^(https?://.*)?$", message = "올바른 URL 형식이어야 합니다.")
         String profileImageUrl
 ) {
     public MemberUpdateRequest {

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -38,6 +38,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private int reviewCount = 0;
 
+    @Column(name = "profile_image_url", columnDefinition = "TEXT")
     private String profileImageUrl;
     // 회원 권한 (현재 USER 단일값, 추후 ADMIN 확장 가능)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/clone/getchu/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/clone/getchu/domain/product/dto/ProductResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public record ProductResponse(
         Long id,
+        Long sellerId,
         String title,
         String description,
         Integer price,
@@ -21,6 +22,7 @@ public record ProductResponse(
     public static ProductResponse from(Product product) {
         return new ProductResponse(
                 product.getId(),
+                product.getSeller().getId(),
                 product.getTitle(),
                 product.getDescription(),
                 product.getPrice(),

--- a/src/main/java/com/clone/getchu/domain/review/service/ReviewService.java
+++ b/src/main/java/com/clone/getchu/domain/review/service/ReviewService.java
@@ -7,6 +7,7 @@ import com.clone.getchu.domain.review.dto.response.ReviewResponse;
 import com.clone.getchu.domain.review.entity.Review;
 import com.clone.getchu.domain.review.repository.ReviewRepository;
 import com.clone.getchu.domain.trade.entity.Trade;
+import com.clone.getchu.domain.trade.enums.TradeRole;
 import com.clone.getchu.domain.trade.enums.TradeStatus;
 import com.clone.getchu.domain.trade.repository.TradeRepository;
 import com.clone.getchu.global.common.CursorPageResponse;
@@ -72,6 +73,7 @@ public class ReviewService {
         );
         reviewRepository.save(review);
         seller.updateReviewStats(request.rating());
+        trade.proceed(TradeRole.BUYER); // SOLD → REVIEWED
     }
 
     /**

--- a/src/main/java/com/clone/getchu/domain/trade/dto/response/GetAllTradeResponse.java
+++ b/src/main/java/com/clone/getchu/domain/trade/dto/response/GetAllTradeResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 public record GetAllTradeResponse (
         Long tradeId,
         String productTitle,
+        Long productId,
         Integer price,
         TradeStatus status,
         LocalDateTime updatedAt //상태가 마지막으로 변경된 날짜
@@ -16,6 +17,7 @@ public record GetAllTradeResponse (
         return new GetAllTradeResponse(
                 trade.getId(),
                 trade.getProduct().getTitle(),
+                trade.getProduct().getId(),
                 trade.getProduct().getPrice(),
                 trade.getStatus(),
                 trade.getUpdatedAt()

--- a/src/main/java/com/clone/getchu/global/config/CacheConfig.java
+++ b/src/main/java/com/clone/getchu/global/config/CacheConfig.java
@@ -14,13 +14,14 @@ import java.util.concurrent.TimeUnit;
 public class CacheConfig {
 
     public static final String POPULAR_KEYWORDS = "popularKeywords";
+    public static final String CATEGORIES = "categories";
     private static final int POPULAR_KEYWORDS_TTL_MINUTES = 10;
     // 검색어 순위는 전체 목록을 하나의 값으로 캐싱하므로 최대 1개 엔트리로 충분
     private static final int POPULAR_KEYWORDS_MAX_SIZE = 1;
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager(POPULAR_KEYWORDS);
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(POPULAR_KEYWORDS, CATEGORIES);
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .expireAfterWrite(POPULAR_KEYWORDS_TTL_MINUTES, TimeUnit.MINUTES)
                 .maximumSize(POPULAR_KEYWORDS_MAX_SIZE));

--- a/src/main/java/com/clone/getchu/global/config/CacheConfig.java
+++ b/src/main/java/com/clone/getchu/global/config/CacheConfig.java
@@ -3,10 +3,12 @@ package com.clone.getchu.global.config;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -15,16 +17,20 @@ public class CacheConfig {
 
     public static final String POPULAR_KEYWORDS = "popularKeywords";
     public static final String CATEGORIES = "categories";
-    private static final int POPULAR_KEYWORDS_TTL_MINUTES = 10;
-    // 검색어 순위는 전체 목록을 하나의 값으로 캐싱하므로 최대 1개 엔트리로 충분
-    private static final int POPULAR_KEYWORDS_MAX_SIZE = 1;
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager(POPULAR_KEYWORDS, CATEGORIES);
-        cacheManager.setCaffeine(Caffeine.newBuilder()
-                .expireAfterWrite(POPULAR_KEYWORDS_TTL_MINUTES, TimeUnit.MINUTES)
-                .maximumSize(POPULAR_KEYWORDS_MAX_SIZE));
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(
+                new CaffeineCache(POPULAR_KEYWORDS, Caffeine.newBuilder()
+                        .expireAfterWrite(10, TimeUnit.MINUTES)
+                        .maximumSize(1)
+                        .build()),
+                new CaffeineCache(CATEGORIES, Caffeine.newBuilder()
+                        .expireAfterWrite(1, TimeUnit.HOURS)
+                        .maximumSize(100)
+                        .build())
+        ));
         return cacheManager;
     }
 }

--- a/src/main/java/com/clone/getchu/global/config/WebSocketConfig.java
+++ b/src/main/java/com/clone/getchu/global/config/WebSocketConfig.java
@@ -19,8 +19,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-chat")
-                .setAllowedOriginPatterns("*")
-                .withSockJS();
+                .setAllowedOriginPatterns("*");
+//                .withSockJS();
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 server:
   port: 8080
+  tomcat:
+    max-http-form-post-size: 50MB
+    max-swallow-size: 50MB
 
 spring:
   application:
@@ -17,10 +20,22 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        defer-datasource-initialization: true
+        sql:
+          init:
+            mode: always
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
+  mvc:
+    async:
+      request-timeout: 30000
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME:900000}      # 15분

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,8 @@ spring:
             mode: always
   servlet:
     multipart:
-      max-file-size: 50MB
-      max-request-size: 50MB
+      max-file-size: 20MB
+      max-request-size: 20MB
   mvc:
     async:
       request-timeout: 30000

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,99 @@
+-- ============================================================
+-- 테스트용 더미 데이터 (INSERT IGNORE: 중복 실행 안전)
+-- 비밀번호: Test1234! (BCrypt 해시)
+-- ============================================================
+
+-- ─── 카테고리 ────────────────────────────────────────────
+INSERT IGNORE INTO category (id, name) VALUES
+(1, '디지털기기'),
+(2, '생활가전'),
+(3, '가구/인테리어'),
+(4, '의류'),
+(5, '도서'),
+(6, '스포츠/레저'),
+(7, '기타');
+
+-- ─── 회원 ────────────────────────────────────────────────
+-- 비밀번호: Test1234!
+INSERT IGNORE INTO members (id, email, password, nickname, profile_image_url, average_rating, review_count, role, deleted, created_at, updated_at) VALUES
+(1, 'buyer@test.com',  '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lh9i', '구매자테스터', NULL, 0.0, 0, 'USER', false, NOW(), NOW()),
+(2, 'seller@test.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lh9i', '판매자테스터', NULL, 4.5, 3, 'USER', false, NOW(), NOW());
+
+-- ─── 상품 ────────────────────────────────────────────────
+INSERT IGNORE INTO PRODUCT (id, seller_id, category_id, title, description, price, status, like_count, is_deleted, created_at, updated_at) VALUES
+-- 판매중 상품 (구매자가 예약/채팅 테스트용)
+(1, 2, 1, '아이패드 Pro 11인치', '2022년 모델, 거의 새것입니다.\n애플펜슬 포함.\n직거래 선호합니다.', 550000, 'SALE', 5, false, NOW(), NOW()),
+(2, 2, 4, '나이키 맨투맨 L사이즈', '한 번 입었습니다. 사이즈 미스로 팝니다.', 35000, 'SALE', 2, false, NOW(), NOW()),
+(3, 2, 3, '이케아 책상 120cm', '2년 사용, 상태 양호합니다. 이사로 인해 급처합니다.', 80000, 'SALE', 8, false, NOW(), NOW()),
+-- 예약중 상품 (판매자가 거래시작 버튼 테스트용)
+(4, 2, 1, '갤럭시 버즈 Pro', '6개월 사용, 케이스 포함입니다.', 120000, 'RESERVED', 3, false, NOW(), NOW()),
+-- 거래중 상품 (판매자가 거래완료 버튼 테스트용)
+(5, 2, 2, '다이슨 청소기 V11', '1년 사용, 흡입력 최상입니다.', 350000, 'RESERVED', 1, false, NOW(), NOW()),
+-- 판매완료 상품 (구매자가 리뷰 작성 테스트용)
+(6, 2, 5, '토익 교재 세트', '최신판, 한 번만 봤습니다.', 25000, 'SOLD_OUT', 0, false, NOW(), NOW());
+
+-- ─── 상품 이미지 ─────────────────────────────────────────
+INSERT IGNORE INTO product_image (product_id, image_url, sort_order) VALUES
+(1, 'https://images.unsplash.com/photo-1544244015-0df4b3ffc6b0?w=600', 0),
+(2, 'https://images.unsplash.com/photo-1556821840-3a63f95609a7?w=600', 0),
+(3, 'https://images.unsplash.com/photo-1518455027359-f3f8164ba6bd?w=600', 0),
+(4, 'https://images.unsplash.com/photo-1590658268037-6bf12165a8df?w=600', 0),
+(5, 'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=600', 0),
+(6, 'https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=600', 0);
+
+-- ─── 거래 ────────────────────────────────────────────────
+-- 예약중 거래 (상품4: 판매자가 거래시작 가능)
+INSERT IGNORE INTO trades (trade_id, product_id, buyer_id, seller_id, status, reserved_at, traded_at, sold_at, created_at, updated_at) VALUES
+(1, 4, 1, 2, 'RESERVED', NOW(), NULL, NULL, NOW(), NOW()),
+-- 거래중 거래 (상품5: 판매자가 거래완료 가능)
+(2, 5, 1, 2, 'TRADING',  NOW(), NOW(), NULL, NOW(), NOW()),
+-- 판매완료 거래 (상품6: 구매자가 리뷰 작성 가능)
+(3, 6, 1, 2, 'SOLD',     NOW(), NOW(), NOW(), NOW(), NOW());
+
+-- ─── 채팅방 ──────────────────────────────────────────────
+-- 구매자(1)↔판매자(2), 상품1 채팅방
+INSERT IGNORE INTO chat_room (id, product_id, buyer_id, seller_id, last_message_at, created_at, updated_at) VALUES
+(1, 1, 1, 2, NOW(), NOW(), NOW());
+
+-- ─── 채팅 메시지 ─────────────────────────────────────────
+INSERT IGNORE INTO chat_message (id, chat_room_id, sender_id, sender_nickname, content, is_read, created_at, updated_at) VALUES
+(1, 1, 1, '구매자테스터', '안녕하세요! 아직 판매 중인가요?', true,  NOW(), NOW()),
+(2, 1, 2, '판매자테스터', '네, 판매 중입니다 :)',             true,  NOW(), NOW()),
+(3, 1, 1, '구매자테스터', '직거래 가능한가요?',               false, NOW(), NOW());
+
+-- ─── 추가 더미 데이터 (짱구 id:9 / 햅삐 id:10) ──────────
+-- 짱구 판매 상품
+INSERT IGNORE INTO PRODUCT (id, seller_id, category_id, title, description, price, status, like_count, is_deleted, created_at, updated_at) VALUES
+(200, 9, 1, '맥북 프로 14인치 M3', '2023년 구매, 스크래치 없음. 충전기 포함.', 1800000, 'SALE', 12, false, NOW(), NOW()),
+(201, 9, 1, '에어팟 프로 2세대', '6개월 사용, 케이스 포함. 배터리 95%.', 180000, 'SALE', 7, false, NOW(), NOW()),
+(202, 9, 4, '무신사 스탠다드 후드티 XL', '한 번 세탁, 상태 좋음. 블랙 컬러.', 28000, 'SALE', 3, false, NOW(), NOW()),
+(203, 9, 6, '나이키 에어맥스 270 270mm', '3회 착용, 박스 있음. 거의 새것.', 95000, 'SALE', 9, false, NOW(), NOW()),
+(204, 9, 5, '토익 LC RC 최신판 세트', '2024년판, 필기 없음. 직거래 선호.', 22000, 'SALE', 2, false, NOW(), NOW()),
+(205, 9, 3, '허먼밀러 의자 에어론', '3년 사용, 허리 지지대 정상. 직거래만.', 650000, 'SALE', 15, false, NOW(), NOW()),
+(206, 9, 2, '다이슨 에어랩 완전체', '1년 사용, 모든 어태치먼트 포함.', 420000, 'SALE', 11, false, NOW(), NOW()),
+
+-- 햅삐 판매 상품
+(210, 10, 1, '갤럭시 S24 울트라 256GB', '3개월 사용, 케이스+필름 부착. 티타늄 블랙.', 950000, 'SALE', 8, false, NOW(), NOW()),
+(211, 10, 1, '아이패드 에어 5세대 WiFi', '1년 사용, 애플펜슬 2세대 포함.', 480000, 'SALE', 6, false, NOW(), NOW()),
+(212, 10, 4, '아디다스 트레이닝복 세트 M', '2회 착용, 상하의 세트. 네이비 컬러.', 45000, 'SALE', 4, false, NOW(), NOW()),
+(213, 10, 6, '요가매트 + 필라테스 소품 세트', '6개월 사용, 세척 완료. 보관 상태 좋음.', 35000, 'SALE', 5, false, NOW(), NOW()),
+(214, 10, 3, '이케아 KALLAX 책장 4x4', '2년 사용, 조립 상태 양호. 직거래만.', 55000, 'SALE', 3, false, NOW(), NOW()),
+(215, 10, 5, '파이썬 프로그래밍 책 3권 세트', '밑줄 없음, 깨끗한 상태.', 18000, 'SALE', 1, false, NOW(), NOW()),
+(216, 10, 2, '쿠쿠 전기밥솥 6인용', '1년 사용, 정상 작동. 박스 없음.', 65000, 'SALE', 7, false, NOW(), NOW());
+
+-- ─── 상품 이미지 ─────────────────────────────────────────
+INSERT IGNORE INTO product_image (product_id, image_url, sort_order) VALUES
+(200, 'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?w=600', 0),
+(201, 'https://images.unsplash.com/photo-1606220945770-b5b6c2c55bf1?w=600', 0),
+(202, 'https://images.unsplash.com/photo-1556821840-3a63f95609a7?w=600', 0),
+(203, 'https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=600', 0),
+(204, 'https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=600', 0),
+(205, 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=600', 0),
+(206, 'https://images.unsplash.com/photo-1522338242992-e1a54906a8da?w=600', 0),
+(210, 'https://images.unsplash.com/photo-1610945415295-d9bbf067e59c?w=600', 0),
+(211, 'https://images.unsplash.com/photo-1544244015-0df4b3ffc6b0?w=600', 0),
+(212, 'https://images.unsplash.com/photo-1515886657613-9f3515b0c78f?w=600', 0),
+(213, 'https://images.unsplash.com/photo-1518611012118-696072aa579a?w=600', 0),
+(214, 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=600', 0),
+(215, 'https://images.unsplash.com/photo-1512820790803-83ca734da794?w=600', 0),
+(216, 'https://images.unsplash.com/photo-1585515320310-259814833e62?w=600', 0);


### PR DESCRIPTION
📝 작업 내용
- 백엔드와 연동을 위해 필요했던 프론트엔드 요청, 응답 필드 수정 및 추가
- 로컬에서 프론트엔드 실행 테스트를 하기위한 더미데이터와 yml 설정 추가

🔍 변경 사항
- 프로필 이미지 깨짐 오류 - Pattern 검증 삭제, Base64 이미지베이스의 컬럼 제한 해제를 위한 기존 String에서 text 컬럼으로 수정
- 구매자가 채팅하기를 다시 누를 시 구매자만 재입장 처리되는 오류 - ChatRoomService createOrGetChatRoom 메서드 로직에room.reenterRoom(sellerId) 추가로 판매자도 같이 재입장할 수 있도록 수정
- 상품 상세페이지에서 채팅방 생성이 안됨 - ProductResponse에 sellerId 필드 추가
- 하나의 거래에 하나의 리뷰만 가능하다는 정책 위반 - 리뷰를 등록함과 동시에 REVIEWED 상태전환 로직 추가
- 거래 목록에서 상품 접근이 불가한 오류 발생 - GetAllTradeResponse prductId 필드 추가
- 상품 수정 시 카테고리를 찾아오지 못해서 500 서버 오류 발생 - @Cacheable("categories") 선언 불일치문제 인지 -> CacheManager에 등록이 안되있어 CacheConfig에 static final 상수로 선언해 하드코딩 방지

✅ 테스트
- [ ] 로컬 실행 확인
- [ ] API 테스트 완료
- [ ] 예외 케이스 확인
- [ ] 기존 기능 영향 확인

📸 스크린샷 / 결과
<img width="1400" height="746" alt="image" src="https://github.com/user-attachments/assets/687f69da-f798-4da8-a4ec-4b40ac189c7b" />


💬 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분
- 고민했던 부분

#️⃣ 연관 이슈
- close #45