### PR TITLE
fix: 닉네임 유니크값 추가+중복체크 메서드,로직 추가

### DIFF
--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -44,18 +44,24 @@ public class AuthService {
         if (memberRepository.existsByEmail(request.email())) {
             throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
         }
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+        }
 
         Member member = Member.builder()
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
                 .nickname(request.nickname())
-                .profileImageUrl(request.profileImageUrl()) // 추가
+                .profileImageUrl(request.profileImageUrl())
                 .build();
 
         try {
             return SignupResponse.from(memberRepository.save(member));
         } catch (DataIntegrityViolationException e) {
-            // DB Unique 제약조건 위반 시 발생 (동시성 제어의 최후 방어선)
+            // 동시성 경쟁으로 사전 체크 통과 후 DB 제약조건 위반 시 재확인
+            if (memberRepository.existsByNickname(request.nickname())) {
+                throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+            }
             throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
         }
     }

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -59,12 +59,13 @@ public class AuthService {
         try {
             return SignupResponse.from(memberRepository.save(member));
         } catch (DataIntegrityViolationException e) {
-            // 동시성 경쟁으로 락+사전 체크 통과 후 DB 제약조건 위반 시 재확인
-            if (memberRepository.existsByNickname(request.nickname()))
+            // 추가 DB 조회 없이 예외 메시지로 위반된 제약조건을 판별
+            // 회원가입의 unique 제약은 email·nickname 둘뿐이므로 닉네임이 아니면 이메일 충돌
+            String msg = e.getMostSpecificCause().getMessage();
+            if (msg != null && msg.contains("uk_member_nickname")) {
                 throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
-            if (memberRepository.existsByEmail(request.email()))
-                throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
-            throw e; // 예상치 못한 제약조건 위반은 원본 예외 전파
+            }
+            throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
         }
     }
 

--- a/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
+++ b/src/main/java/com/clone/getchu/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.clone.getchu.domain.auth.dto.SignupRequest;
 import com.clone.getchu.domain.auth.dto.SignupResponse;
 import com.clone.getchu.domain.member.entity.Member;
 import com.clone.getchu.domain.member.repository.MemberRepository;
+import com.clone.getchu.domain.member.service.MemberService;
 import com.clone.getchu.global.exception.ConflictException;
 import com.clone.getchu.global.exception.ErrorCode;
 import com.clone.getchu.global.exception.NotFoundException;
@@ -29,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 public class AuthService {
 
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate stringRedisTemplate;
@@ -44,9 +46,8 @@ public class AuthService {
         if (memberRepository.existsByEmail(request.email())) {
             throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
         }
-        if (memberRepository.existsByNickname(request.nickname())) {
-            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
-        }
+        // 닉네임 중복 체크 + Lettuce SETNX 락 (공통 검증 위임)
+        memberService.validateNicknameAvailable(request.nickname(), null);
 
         Member member = Member.builder()
                 .email(request.email())
@@ -58,11 +59,12 @@ public class AuthService {
         try {
             return SignupResponse.from(memberRepository.save(member));
         } catch (DataIntegrityViolationException e) {
-            // 동시성 경쟁으로 사전 체크 통과 후 DB 제약조건 위반 시 재확인
-            if (memberRepository.existsByNickname(request.nickname())) {
+            // 동시성 경쟁으로 락+사전 체크 통과 후 DB 제약조건 위반 시 재확인
+            if (memberRepository.existsByNickname(request.nickname()))
                 throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
-            }
-            throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
+            if (memberRepository.existsByEmail(request.email()))
+                throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
+            throw e; // 예상치 못한 제약조건 위반은 원본 예외 전파
         }
     }
 

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -67,7 +67,6 @@ public class Member extends BaseEntity {
         this.deleted = false;
     }
 
-    // TODO [v2] Review 도메인 구현 후 연동 예정
     // - 리뷰 작성 시 updateReviewStats() 호출 / 거래 완료(SOLD) 상태 구매자만 작성 가능
     public void updateReviewStats(BigDecimal newRating) {
         // 새 평균 = (기존 평균 * 기존 리뷰 수 + 새 별점) / (기존 리뷰 수 + 1)

--- a/src/main/java/com/clone/getchu/domain/member/entity/Member.java
+++ b/src/main/java/com/clone/getchu/domain/member/entity/Member.java
@@ -12,7 +12,12 @@ import org.hibernate.annotations.SQLRestriction;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 @Entity
-@Table(name = "members")
+@Table(
+        name = "members",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_nickname", columnNames = "nickname")
+        }
+)
 @SQLRestriction("deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/com/clone/getchu/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/clone/getchu/domain/member/repository/MemberRepository.java
@@ -17,6 +17,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 회원가입 시 이메일 중복 체크
     boolean existsByEmail(String email);
 
+    // 닉네임 중복 체크
+    boolean existsByNickname(String nickname);
+
     // 리뷰 평점 통계 업데이트 시 동시성 보호 — 비관적 쓰기 락
     // 같은 판매자에게 리뷰가 동시에 작성될 경우 Lost Update 방지
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
+++ b/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
@@ -11,10 +11,14 @@ import com.clone.getchu.global.exception.ErrorCode;
 import com.clone.getchu.global.exception.InvalidRequestException;
 import com.clone.getchu.global.exception.NotFoundException;
 import com.clone.getchu.global.security.CustomUserDetails;
+import com.clone.getchu.global.util.RedisKeyConstants;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final StringRedisTemplate stringRedisTemplate;
 
     // 내 정보 조회(로그인 필요)
     public MemberResponse getMyInfo(Long memberId) {
@@ -36,14 +41,36 @@ public class MemberService {
         Member member = memberRepository.findById(userDetails.getMemberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-        // 닉네임을 변경하는 경우에만 중복 체크 (자기 자신의 현재 닉네임은 허용)
-        if (request.nickname() != null && !request.nickname().equals(member.getNickname())
-                && memberRepository.existsByNickname(request.nickname())) {
-            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
-        }
+        validateNicknameAvailable(request.nickname(), member.getNickname());
 
         member.update(request.nickname(), request.profileImageUrl());
         return MemberResponse.from(member);
+    }
+
+    /**
+     * 닉네임 사용 가능 여부 검증 (Lettuce SETNX 락 + DB 중복 체크)
+     *
+     * - nickname이 null이거나 현재 닉네임과 동일하면 검증 생략
+     * - SETNX로 락 획득 실패 시: 다른 요청이 같은 닉네임을 처리 중 → 409
+     * - 락 획득 후 DB 중복 확인 → 409
+     * - 락은 check 범위만 보호. save 이후는 DB unique constraint가 최종 방어선.
+     */
+    public void validateNicknameAvailable(String nickname, String currentNickname) {
+        if (nickname == null || nickname.equals(currentNickname)) return;
+
+        String lockKey = RedisKeyConstants.nicknameLockKey(nickname);
+        Boolean acquired = stringRedisTemplate.opsForValue()
+                .setIfAbsent(lockKey, "1", 5, TimeUnit.SECONDS);
+        if (!Boolean.TRUE.equals(acquired)) {
+            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+        try {
+            if (memberRepository.existsByNickname(nickname)) {
+                throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+            }
+        } finally {
+            stringRedisTemplate.delete(lockKey);
+        }
     }
 
     // 회원 탈퇴 (소프트 삭제)

--- a/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
+++ b/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
@@ -14,16 +14,26 @@ import com.clone.getchu.global.security.CustomUserDetails;
 import com.clone.getchu.global.util.RedisKeyConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
+    // 내 UUID와 일치할 때만 삭제 — TTL 초과 후 다른 스레드가 획득한 락을 실수로 해제하는 것을 방지
+    private static final RedisScript<Long> UNLOCK_SCRIPT = new DefaultRedisScript<>(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+            Long.class
+    );
+
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final StringRedisTemplate stringRedisTemplate;
@@ -51,16 +61,19 @@ public class MemberService {
      * 닉네임 사용 가능 여부 검증 (Lettuce SETNX 락 + DB 중복 체크)
      *
      * - nickname이 null이거나 현재 닉네임과 동일하면 검증 생략
-     * - SETNX로 락 획득 실패 시: 다른 요청이 같은 닉네임을 처리 중 → 409
-     * - 락 획득 후 DB 중복 확인 → 409
+     * - SETNX 실패: 다른 스레드가 동일 닉네임을 처리 중 → 409
+     * - 락 값에 UUID 사용: TTL 초과 후 다른 스레드가 재획득한 락을 실수로 해제하는 것을 방지
+     * - Lua 스크립트로 "UUID 확인 + 삭제"를 원자적으로 처리
      * - 락은 check 범위만 보호. save 이후는 DB unique constraint가 최종 방어선.
      */
     public void validateNicknameAvailable(String nickname, String currentNickname) {
         if (nickname == null || nickname.equals(currentNickname)) return;
 
         String lockKey = RedisKeyConstants.nicknameLockKey(nickname);
+        String lockValue = UUID.randomUUID().toString();
+
         Boolean acquired = stringRedisTemplate.opsForValue()
-                .setIfAbsent(lockKey, "1", 5, TimeUnit.SECONDS);
+                .setIfAbsent(lockKey, lockValue, 5, TimeUnit.SECONDS);
         if (!Boolean.TRUE.equals(acquired)) {
             throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
         }
@@ -69,7 +82,8 @@ public class MemberService {
                 throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
             }
         } finally {
-            stringRedisTemplate.delete(lockKey);
+            // 내 UUID와 일치할 때만 삭제 (원자적 실행)
+            stringRedisTemplate.execute(UNLOCK_SCRIPT, List.of(lockKey), lockValue);
         }
     }
 

--- a/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
+++ b/src/main/java/com/clone/getchu/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.clone.getchu.domain.member.dto.response.MemberProfileResponse;
 import com.clone.getchu.domain.member.dto.response.MemberResponse;
 import com.clone.getchu.domain.member.entity.Member;
 import com.clone.getchu.domain.member.repository.MemberRepository;
+import com.clone.getchu.global.exception.ConflictException;
 import com.clone.getchu.global.exception.ErrorCode;
 import com.clone.getchu.global.exception.InvalidRequestException;
 import com.clone.getchu.global.exception.NotFoundException;
@@ -34,6 +35,13 @@ public class MemberService {
     public MemberResponse update(CustomUserDetails userDetails, MemberUpdateRequest request) {
         Member member = memberRepository.findById(userDetails.getMemberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 닉네임을 변경하는 경우에만 중복 체크 (자기 자신의 현재 닉네임은 허용)
+        if (request.nickname() != null && !request.nickname().equals(member.getNickname())
+                && memberRepository.existsByNickname(request.nickname())) {
+            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
         member.update(request.nickname(), request.profileImageUrl());
         return MemberResponse.from(member);
     }

--- a/src/main/java/com/clone/getchu/global/exception/ErrorCode.java
+++ b/src/main/java/com/clone/getchu/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "M002", "현재 비밀번호가 올바르지 않습니다."),
     SAME_AS_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "M003", "새 비밀번호는 현재 비밀번호와 달라야 합니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "M004", "이미 사용 중인 닉네임입니다."),
     // ===== CATEGORY (C) =====
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "존재하지 않는 카테고리입니다."),
     // ===== PRODUCT (P) =====

--- a/src/main/java/com/clone/getchu/global/util/RedisKeyConstants.java
+++ b/src/main/java/com/clone/getchu/global/util/RedisKeyConstants.java
@@ -21,6 +21,9 @@ public final class RedisKeyConstants {
 
     // Access Token 블랙리스트: "BL:{accessToken}"
     private static final String BL_PREFIX = "BL:";
+
+    // 닉네임 선점 락: "LOCK:NICKNAME:{nickname}"
+    private static final String NICKNAME_LOCK_PREFIX = "LOCK:NICKNAME:";
     /**
      * Refresh Token Redis 키 생성
      * 예: refreshTokenKey(1L) → "RT:1"
@@ -35,5 +38,13 @@ public final class RedisKeyConstants {
      */
     public static String blacklistKey(String accessToken) {
         return BL_PREFIX + accessToken;
+    }
+
+    /**
+     * 닉네임 선점 락 Redis 키 생성
+     * 예: nicknameLockKey("홍길동") → "LOCK:NICKNAME:홍길동"
+     */
+    public static String nicknameLockKey(String nickname) {
+        return NICKNAME_LOCK_PREFIX + nickname;
     }
 }


### PR DESCRIPTION
📝 작업 내용
- 멤버 엔티티 닉네임 필드에 유니크값 추가 
- 멤버 레포지토리에 닉네임 중복체크 메서드 추가
- 멤버 서비스에 닉네임 중복체크 로직 추가
- 닉네임 중복체크 에러코드 추가

🔍 변경 사항
- 닉네임 중복체크 추가

✅ 테스트
- [ ] 로컬 실행 확인
- [ ] API 테스트 완료
- [ ] 예외 케이스 확인
- [ ] 기존 기능 영향 확인

📸 스크린샷 / 결과
- 필요 시 첨부

💬 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분
- 고민했던 부분

#️⃣ 연관 이슈
- close #48