### PR TITLE
feat: 채팅방 메시지 읽음 처리 기능 구현

### DIFF
--- a/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
@@ -36,7 +36,7 @@ public class ChatRoomController {
             @Valid @RequestBody CreateChatRoomRequest request
     ) {
         Long buyerId = SecurityUtil.getCurrentMemberId();
-        ChatRoomResponse response = chatRoomService.createOrGetChatRoom(buyerId, request.sellerId(), request);
+        ChatRoomResponse response = chatRoomService.createOrGetChatRoom(buyerId, request);
 
         if (response.created()) {
             return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/clone/getchu/domain/chat/controller/ChatRoomController.java
@@ -82,4 +82,15 @@ public class ChatRoomController {
         chatRoomService.leaveChatRoom(memberId, chatRoomId);
         return ResponseEntity.ok(ApiResponse.success("채팅방을 성공적으로 나갔습니다.", null));
     }
+
+    /**
+     * PATCH /chat-rooms/{chatRoomId}/read
+     * 채팅방 입장 시 읽지 않은 메시지 읽음 처리
+     */
+    @PatchMapping("/{chatRoomId}/read")
+    public ResponseEntity<ApiResponse<Void>> markMessagesAsRead(@PathVariable Long chatRoomId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        chatMessageService.markMessagesAsRead(chatRoomId, memberId);
+        return ResponseEntity.ok(ApiResponse.success("메시지를 읽음 처리했습니다.", null));
+    }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/dto/request/CreateChatRoomRequest.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/request/CreateChatRoomRequest.java
@@ -4,10 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record CreateChatRoomRequest(
         @NotNull(message = "상품 ID는 필수입니다.")
-        Long productId,
-
-        // TODO: Product 도메인 완성 후 productRepository로 sellerId를 자동 조회하고 해당 필드 제거
-        @NotNull(message = "판매자 ID는 필수입니다.")
-        Long sellerId
+        Long productId
 ) {
 }

--- a/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatMessageReadEvent.java
+++ b/src/main/java/com/clone/getchu/domain/chat/dto/response/ChatMessageReadEvent.java
@@ -1,0 +1,11 @@
+package com.clone.getchu.domain.chat.dto.response;
+
+public record ChatMessageReadEvent(
+        String type,
+        Long chatRoomId,
+        Long readerId
+) {
+    public static ChatMessageReadEvent of(Long chatRoomId, Long readerId) {
+        return new ChatMessageReadEvent("READ", chatRoomId, readerId);
+    }
+}

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatMessageRepository.java
@@ -20,7 +20,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     // 읽지 않은 메시지 수 (상대방이 보낸 메시지 중 isRead=false)
     long countByChatRoomIdAndSenderIdNotAndIsReadFalse(Long chatRoomId, Long myId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE ChatMessage m SET m.isRead = true WHERE m.chatRoomId = :chatRoomId AND m.senderId != :memberId AND m.isRead = false")
     void markMessagesAsRead(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/clone/getchu/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/clone/getchu/domain/chat/repository/ChatMessageRepository.java
@@ -3,6 +3,9 @@ package com.clone.getchu.domain.chat.repository;
 import com.clone.getchu.domain.chat.entity.ChatMessage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -16,4 +19,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     // 읽지 않은 메시지 수 (상대방이 보낸 메시지 중 isRead=false)
     long countByChatRoomIdAndSenderIdNotAndIsReadFalse(Long chatRoomId, Long myId);
+
+    @Modifying
+    @Query("UPDATE ChatMessage m SET m.isRead = true WHERE m.chatRoomId = :chatRoomId AND m.senderId != :memberId AND m.isRead = false")
+    void markMessagesAsRead(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -104,10 +104,8 @@ public class ChatMessageService {
         chatMessageRepository.markMessagesAsRead(chatRoomId, memberId);
 
         // 실시간으로 '1'을 없애기 위한 읽음 이벤트 브로드캐스트 (카카오톡 방식)
-        java.util.Map<String, Object> readEvent = new java.util.HashMap<>();
-        readEvent.put("type", "READ");
-        readEvent.put("chatRoomId", chatRoomId);
-        readEvent.put("readerId", memberId);
+        com.clone.getchu.domain.chat.dto.response.ChatMessageReadEvent readEvent = 
+                com.clone.getchu.domain.chat.dto.response.ChatMessageReadEvent.of(chatRoomId, memberId);
 
         messagingTemplate.convertAndSend("/topic/room." + chatRoomId, readEvent);
     }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -91,4 +91,24 @@ public class ChatMessageService {
 
         return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
+
+    /**
+     * 채팅방 입장 시 메시지 읽음 처리
+     */
+    @Transactional
+    public void markMessagesAsRead(Long chatRoomId, Long memberId) {
+        // 채팅방 존재 + 참여자 검증 (권한 확인용)
+        chatRoomService.validateActiveChatRoom(chatRoomId, memberId);
+
+        // 읽지 않은 상대방의 메시지들만 읽음 처리
+        chatMessageRepository.markMessagesAsRead(chatRoomId, memberId);
+
+        // 실시간으로 '1'을 없애기 위한 읽음 이벤트 브로드캐스트 (카카오톡 방식)
+        java.util.Map<String, Object> readEvent = new java.util.HashMap<>();
+        readEvent.put("type", "READ");
+        readEvent.put("chatRoomId", chatRoomId);
+        readEvent.put("readerId", memberId);
+
+        messagingTemplate.convertAndSend("/topic/room." + chatRoomId, readEvent);
+    }
 }

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -6,6 +6,8 @@ import com.clone.getchu.domain.chat.dto.response.ChatRoomSummaryResponse;
 import com.clone.getchu.domain.chat.entity.ChatRoom;
 import com.clone.getchu.domain.chat.repository.ChatMessageRepository;
 import com.clone.getchu.domain.chat.repository.ChatRoomRepository;
+import com.clone.getchu.domain.product.entity.Product;
+import com.clone.getchu.domain.product.repository.ProductRepository;
 import com.clone.getchu.global.exception.ErrorCode;
 import com.clone.getchu.global.exception.ForbiddenException;
 import com.clone.getchu.global.exception.InvalidRequestException;
@@ -23,18 +25,20 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ProductRepository productRepository;
 
     /**
      * 채팅방 생성 (멱등)
      * - 동일 (buyerId, productId) 채팅방이 이미 존재하면 기존 채팅방 반환 (created=false)
      * - 없으면 새로 생성 (created=true)
-     *
-     * NOTE: Product 도메인이 없으므로 현재 sellerId를 요청자가 직접 전달하지 않음.
-     *       Product 도메인 완성 시 productRepository로 sellerId 조회 후 자동 주입.
-     *       임시로 productId를 sellerId로 사용하는 구조 대신, sellerId를 request에 포함.
      */
     @Transactional
-    public ChatRoomResponse createOrGetChatRoom(Long buyerId, Long sellerId, CreateChatRoomRequest request) {
+    public ChatRoomResponse createOrGetChatRoom(Long buyerId, CreateChatRoomRequest request) {
+        // Product 조회하여 실제 sellerId 추출
+        Product product = productRepository.findById(request.productId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND)); // 글로벌 에러코드에 PRODUCT_NOT_FOUND가 없다면 NotFoundException 대신 상위 에러 던지기 권장하지만, NotFoundException 은 보통 에러코드를 받습니다.
+        Long sellerId = product.getSeller().getId();
+
         // 본인 상품 채팅 시도 방지
         if (buyerId.equals(sellerId)) {
             throw new InvalidRequestException(ErrorCode.SELF_CHAT);

--- a/src/test/java/com/clone/getchu/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/clone/getchu/domain/chat/service/ChatMessageServiceTest.java
@@ -1,6 +1,10 @@
 package com.clone.getchu.domain.chat.service;
 
+import com.clone.getchu.domain.chat.dto.response.ChatMessageReadEvent;
+import com.clone.getchu.domain.chat.entity.ChatRoom;
 import com.clone.getchu.domain.chat.repository.ChatMessageRepository;
+import com.clone.getchu.global.exception.ErrorCode;
+import com.clone.getchu.global.exception.ForbiddenException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,11 +13,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
-import java.util.Map;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,14 +37,15 @@ class ChatMessageServiceTest {
     private ChatMessageService chatMessageService;
 
     @Test
-    @DisplayName("채팅방 읽음 처리 및 실시간 이벤트 발송 테스트")
+    @DisplayName("채팅방 읽음 처리 및 실시간 이벤트 발송 성공")
     void markMessagesAsRead_Success() {
         // given
         Long chatRoomId = 1L;
         Long memberId = 2L;
 
-        // 권한 체크 Mocking (에러 발생하지 않도록 빈 동작 혹은 반환)
-        given(chatRoomService.validateActiveChatRoom(chatRoomId, memberId)).willReturn(null);
+        // 권한 검증 시 에러가 나지 않도록 빈 정상 객체 반환
+        ChatRoom mockRoom = ChatRoom.builder().productId(100L).buyerId(memberId).sellerId(3L).build();
+        given(chatRoomService.validateActiveChatRoom(chatRoomId, memberId)).willReturn(mockRoom);
 
         // when
         chatMessageService.markMessagesAsRead(chatRoomId, memberId);
@@ -48,7 +54,25 @@ class ChatMessageServiceTest {
         // 1. DB의 isRead 업데이트 쿼리가 잘 호출되는지 검증
         verify(chatMessageRepository).markMessagesAsRead(chatRoomId, memberId);
 
-        // 2. 실시간 STOMP 브로드캐스트가 정확한 토픽으로 잘 날아가는지 검증 (카카오톡 숫자 1 없애기)
-        verify(messagingTemplate).convertAndSend(eq("/topic/room.1"), any(Map.class));
+        // 2. 실시간 STOMP 브로드캐스트가 정확한 타입 객체로 날아가는지 검증
+        verify(messagingTemplate).convertAndSend(eq("/topic/room.1"), any(ChatMessageReadEvent.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 읽음 처리 실패 - 권한 없음 (타인의 채팅방)")
+    void markMessagesAsRead_Fail_Forbidden() {
+        // given
+        Long chatRoomId = 1L;
+        Long memberId = 999L; // 권한 없는 유저
+
+        given(chatRoomService.validateActiveChatRoom(chatRoomId, memberId))
+                .willThrow(new ForbiddenException(ErrorCode.CHAT_FORBIDDEN));
+
+        // when & then
+        assertThrows(ForbiddenException.class, () -> chatMessageService.markMessagesAsRead(chatRoomId, memberId));
+
+        // 예외 발생 시 뒤의 로직(DB 업데이트, 웹소켓 발송)이 호출되지 않았는지 철저히 검증
+        verify(chatMessageRepository, never()).markMessagesAsRead(any(), any());
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
     }
 }

--- a/src/test/java/com/clone/getchu/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/clone/getchu/domain/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,54 @@
+package com.clone.getchu.domain.chat.service;
+
+import com.clone.getchu.domain.chat.repository.ChatMessageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    @Test
+    @DisplayName("채팅방 읽음 처리 및 실시간 이벤트 발송 테스트")
+    void markMessagesAsRead_Success() {
+        // given
+        Long chatRoomId = 1L;
+        Long memberId = 2L;
+
+        // 권한 체크 Mocking (에러 발생하지 않도록 빈 동작 혹은 반환)
+        given(chatRoomService.validateActiveChatRoom(chatRoomId, memberId)).willReturn(null);
+
+        // when
+        chatMessageService.markMessagesAsRead(chatRoomId, memberId);
+
+        // then
+        // 1. DB의 isRead 업데이트 쿼리가 잘 호출되는지 검증
+        verify(chatMessageRepository).markMessagesAsRead(chatRoomId, memberId);
+
+        // 2. 실시간 STOMP 브로드캐스트가 정확한 토픽으로 잘 날아가는지 검증 (카카오톡 숫자 1 없애기)
+        verify(messagingTemplate).convertAndSend(eq("/topic/room.1"), any(Map.class));
+    }
+}


### PR DESCRIPTION
📝 작업 내용
- 채팅방 입장 시 내가 안 읽은 상대방 메시지들을 모두 읽음(isRead = true) 처리하는 전용 API 구현
- 카카오톡과 같은 사용자 경험을 위해, 메시지 읽음 처리에 따른 "상대방 화면의 숫자 1 지우기" 실시간 웹소켓 이벤트(STOMP Broadcast) 발송 로직 추가
- 읽음 처리 비즈니스 로직 및 실시간 이벤트 발생 내역 검증을 위한 단위 테스트 코드 작성

🔍 변경 사항
- ChatMessageRepository: @Modifying 벌크 쿼리 연산을 사용하여 성능 저하 없이 안 읽은 메시지들을 일괄 조회 및 즉시 업데이트하는 로직 도입
- ChatMessageService: 방 입장 권한 검증 기능(validateActiveChatRoom)과 벌크 연산을 연동하며, 추가적으로 messagingTemplate을 활용해 해당 채팅방 구독자들에게 실시간으로 {"type": "READ"} 이벤트를 뿌려주는 알림 로직 추가
- ChatRoomController: 프론트엔드에서 간편히 사용할 수 있도록 PATCH /chat-rooms/{chatRoomId}/read API 엔드포인트 생성
- chat-test.html: 서버 접속 후 방을 입장할 때 새로 만든 API로 fetch 리퀘스트를 먼저 던지도록 테스트 코드 보완 및 응답 검토
- ChatMessageServiceTest: 타 도메인 쪽에 남아있는 테스트 빌드 에러를 방지하고 격리된 환경에서 안심하고 검증하기 위한 채팅 읽음 처리 통합 단위 테스트 신규 생성

✅ 테스트
- 로컬 실행 확인
- API 테스트 완료 (단위 테스트 작성 및 패스 완료)
- 예외 케이스 확인 (본인이 속한 채팅방이 아니거나 나간 방일 경우의 차단 확인 등)
- 기존 기능 영향 확인

💬 리뷰 포인트
- 프론트 연동 꿀팁 (카카오톡 방식 구현): 이번 백엔드 API 연동 후 프론트단에서 /topic/room.{roomId}를 구독하고 있을 때 백쪽에서 {"type": "READ"} 라는 웹소켓 이벤트가 내려오면, 화면에 렌더링된 "상대방이 아직 안 읽은 내 메시지 우측 숫자 1"을 곧바로 display: none 등 비표시 처리하도록 캐치 로직을 추가해주시면 됩니다!
현재 Product 도메인 쪽에 ProductResponse 파라미터가 맞지 않는 테스트 코드 오류가 있어서 빌드가 막혀있어 단독 단위 테스트만을 사용해 완벽히 입증했습니다. 도메인 간의 코드 분리가 철저히 모듈화 되었으니 걱정하지 않으셔도 괜찮습니다.