### PR TITLE
refactor: DB를 직접 조회해서 사용하도록 보안 설계 수정

### DIFF
--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatRoomService.java
@@ -36,7 +36,7 @@ public class ChatRoomService {
     public ChatRoomResponse createOrGetChatRoom(Long buyerId, CreateChatRoomRequest request) {
         // Product 조회하여 실제 sellerId 추출
         Product product = productRepository.findById(request.productId())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND)); // 글로벌 에러코드에 PRODUCT_NOT_FOUND가 없다면 NotFoundException 대신 상위 에러 던지기 권장하지만, NotFoundException 은 보통 에러코드를 받습니다.
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
         Long sellerId = product.getSeller().getId();
 
         // 본인 상품 채팅 시도 방지


### PR DESCRIPTION
📝 작업 내용
- 프론트엔드에서 채팅방 개설 시 임의로 sellerId를 넘길 시 발생할 수 있는 보안 취약점 사전 차단
- 채팅방 생성 로직을 Product 도메인과 연계하여, DB에서 직접 판매자를 식별하는 안전한 구조로 리팩토링

🔍 변경 사항
- CreateChatRoomRequest: 클라이언트가 전송하던 sellerId 프로퍼티 삭제 및 임시 TODO 주석 제거 (이제 productId만 받음)
- ChatRoomController: DTO 구조 변경에 따라 컨트롤러에서 서비스로 넘겨주는 파라미터 뎁스 간소화
- ChatRoomService: ProductRepository를 신규 의존성으로 주입. 넘어온 productId로 실제 상품 데이터를 조회해 진짜 판매자의 ID값(.getSeller().getId())을 추출한 후 채팅방을 만들도록 변경 (없는 상품일 경우 PRODUCT_NOT_FOUND 예외 처리)

✅ 테스트
 - 로컬 실행 확인
 - API 테스트 완료 (컴파일 및 로직 검증 완료)
 - 예외 케이스 확인 (비정상적인 상품 ID를 통해 접근 시 NotFound 필터링)
 - 기존 기능 영향 확인

💬 리뷰 포인트
- 프론트 연동 주의 사항: 기존 채팅방 생성 API 호출 시 클라이언트 모델에서 넘겨주던 sellerId 필드를 더 이상 받지 않게 되었습니다. 프론트엔드 담당자께서는 생성 요청 객체에서 해당 프로퍼티를 제외하고 productId만 던져주시길 바랍니다!
타 도메인을 직접 수정하지 않되, 단방향 의존(ProductRepository)만 이끌어와서 채팅 서비스의 안정성을 크게 높였으니 의존성 관계 부분도 함께 살펴봐주시면 감사하겠습니다.