### PR TITLE
Feat/#54 like count

### DIFF
--- a/src/main/java/com/clone/getchu/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/clone/getchu/domain/like/repository/LikeRepository.java
@@ -25,12 +25,12 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Page<Like> findAllByMemberId(Long memberId, Pageable pageable);
 
     //상품의 찜 수 증가
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Product p SET p.likeCount = p.likeCount + 1 WHERE p.id = :productId")
-    void incrementLikeCount(@Param("productId") Long productId);
+//    @Modifying(clearAutomatically = true)
+//    @Query("UPDATE Product p SET p.likeCount = p.likeCount + 1 WHERE p.id = :productId")
+//    void incrementLikeCount(@Param("productId") Long productId);
 
     //상품의 찜 수 감소
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Product p SET p.likeCount = p.likeCount - 1 WHERE p.id = :productId AND p.likeCount > 0")
-    void decrementLikeCount(@Param("productId") Long productId);
+//    @Modifying(clearAutomatically = true)
+//    @Query("UPDATE Product p SET p.likeCount = p.likeCount - 1 WHERE p.id = :productId AND p.likeCount > 0")
+//    void decrementLikeCount(@Param("productId") Long productId);
 }

--- a/src/main/java/com/clone/getchu/domain/like/service/LikeFacade.java
+++ b/src/main/java/com/clone/getchu/domain/like/service/LikeFacade.java
@@ -24,7 +24,7 @@ public class LikeFacade {
 
     //찜삭제
     public void deleteLike(Long productId, Long memberId){
-        String lockKey = "lock:product:"+productId+":member:"+memberId;
+        String lockKey = "lock:product:"+productId;
 
         lockService.executeWithLock(lockKey, () -> {
             likeService.deleteLike(productId, memberId);

--- a/src/main/java/com/clone/getchu/domain/like/service/LikeService.java
+++ b/src/main/java/com/clone/getchu/domain/like/service/LikeService.java
@@ -28,28 +28,28 @@ public class LikeService {
 
     @Transactional
     public void createLike(Long productId, Long memberId) {
+        //상품 조회
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
+
         //삭제된 이력 포함해서 전체 데이터 조회
         Like like = likeRepository.findByProductIdAndMemberIdIncludingDeleted(productId, memberId)
                 .orElse(null);
 
         if (like != null) {
-            if (!like.isDeleted()) {
-                // 이미 찜한 상태라면 카운트를 증가시키지 않고 무시 (멱등성 보장)
-                return;
-            }
+            if (!like.isDeleted()) return;
             //이전에 취소한 이력이 있다면 다시 활성화
             like.restore();
         } else {
             //처음 찜하는 경우
-            Product product = productRepository.findById(productId)
-                    .orElseThrow(() -> new NotFoundException(ErrorCode.PRODUCT_NOT_FOUND));
             Member member = memberRepository.findById(memberId)
                     .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
             likeRepository.save(new Like(product, member));
         }
 
-        likeRepository.incrementLikeCount(productId);
+        //객체 필드값을 직접 수정 (Dirty Checking) - 별도의 쿼리 호출 없이도 트랜잭션 종료 시 DB와 일치됨
+        product.incrementLikeCount();
     }
 
     @Transactional
@@ -60,8 +60,7 @@ public class LikeService {
 
         like.softDelete();
 
-        // 테이블의 likeCount 감소
-        likeRepository.decrementLikeCount(productId);
+        like.getProduct().decrementLikeCount();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
📝 작업 내용
- JPA 영속성 컨텍스트 데이터 동기화
- 동시성 제어 단위를 상품 레벨로 통일
- 벌크 연산 대신 엔티티의 비즈니스 로직(Dirty Checking)을 활용하도록 리팩토링

🔍 변경 사항
LikeService.java
- 기존: LikeRepository의 네이티브 쿼리를 직접 호출하여 DB 숫자만 올림 (이 과정에서 이미 로드된 엔티티의 예전 값(0)이 나중에 DB를 덮어쓰는 버그 발생)
- 수정: product.incrementLikeCount()를 호출하여 엔티티 객체의 상태를 먼저 변경. 트랜잭션 종료 시 JPA가 변경된 상태를 감지하여 정확한 최종값을 DB에 반영

LikeFacade.java
- 기존: 찜 삭제 시 사용자-상품 단위로 락을 걸어, 서로 다른 사용자가 동시에 같은 상품의 찜을 취소할 때 카운트가 꼬일 위험이 있었음
- 수정: 찜하기와 찜 삭제 모두 상품(productId) 단위로 락 키를 통일하여 어떤 상황에서도 해당 상품의 카운트를 순차적으로 안전하게 처리함

✅ 테스트
- [ ] 로컬 실행 확인
- [ ] API 테스트 완료
- [ ] 예외 케이스 확인
- [ ] 기존 기능 영향 확인

📸 스크린샷 / 결과
- 필요 시 첨부

💬 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분
- 고민했던 부분

#️⃣ 연관 이슈
- close #54 