### PR TITLE
fix: 채팅방 재초대 오류 수정

### DIFF
--- a/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/clone/getchu/domain/chat/entity/ChatRoom.java
@@ -76,6 +76,11 @@ public class ChatRoom extends BaseEntity {
         }
     }
 
+    public void reopenForParticipants() {
+        this.deletedByBuyer = false;
+        this.deletedBySeller = false;
+    }
+
     public boolean isLeftBy(Long memberId) {
         if (this.buyerId.equals(memberId)) {
             return this.deletedByBuyer;

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -46,9 +46,9 @@ public class ChatMessageService {
                 .build();
         chatMessageRepository.save(message);
 
-        // lastMessageAt 갱신 & 메시지를 보낸 사람의 퇴장 상태만 복구
+        // lastMessageAt 갱신 & 메시지가 오면 양쪽 참여자에게 채팅방을 다시 노출
         chatRoom.updateLastMessageAt(LocalDateTime.now());
-        chatRoom.reenterRoom(senderId);
+        chatRoom.reopenForParticipants();
 
         // STOMP 브로드캐스트 → /topic/room.{chatRoomId}
         ChatMessageResponse response = ChatMessageResponse.from(message);

--- a/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/clone/getchu/domain/chat/service/ChatMessageService.java
@@ -46,8 +46,9 @@ public class ChatMessageService {
                 .build();
         chatMessageRepository.save(message);
 
-        // lastMessageAt 갱신 & 메시지가 오면 양쪽 참여자에게 채팅방을 다시 노출
         chatRoom.updateLastMessageAt(LocalDateTime.now());
+        // 판매자는 상품 페이지를 통해서만 채팅방 재진입이 가능하므로,
+        // 새 메시지 수신 시 나간 참여자도 채팅방이 다시 보이도록 양쪽 모두 복원 (카카오톡 방식)
         chatRoom.reopenForParticipants();
 
         // STOMP 브로드캐스트 → /topic/room.{chatRoomId}


### PR DESCRIPTION
📝 작업 내용
- 채팅방 나가기 이후 상대방 메시지 전송 시 채팅방이 다시 노출되도록 재입장 처리 로직 수정
- ChatRoom 엔티티에 양쪽 참여자의 deleted 플래그를 모두 복구하는 메서드 추가
- ChatMessageService에서 메시지 전송 시 sender만 복구하던 기존 로직을 양쪽 참여자 복구 로직으로 변경
🔍 변경 사항
- 기존: 메시지 전송 시 `reenterRoom(senderId)`를 호출해 메시지를 보낸 사람의 `deleted_by_*` 플래그만 false로 변경
- 변경: 메시지 전송 시 buyer/seller 양쪽의 `deleted_by_buyer`, `deleted_by_seller` 플래그를 모두 false로 변경
- 결과: 한쪽 사용자가 채팅방을 나간 뒤 남아 있는 사용자가 메시지를 보내면, 나갔던 사용자 채팅 목록에도 해당 방이 다시 표시됨

✅ 테스트
- [ ] 로컬 실행 확인
- [ ] API 테스트 완료
- [ ] 예외 케이스 확인
- [ ] 기존 기능 영향 확인

📸 스크린샷 / 결과
- 필요 시 첨부

💬 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분
- 고민했던 부분

#️⃣ 연관 이슈
- close #65 